### PR TITLE
ci: update actions to latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Install system deps
         run: |
@@ -59,7 +59,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 120
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Install system deps
         run: |
@@ -96,7 +96,7 @@ jobs:
           echo "smoke ok"
 
       - name: Upload gork binary
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: gork-linux-x86_64
           path: target/release/gork


### PR DESCRIPTION
will fix https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

@thedavidweng could you enable issues for this repo? also the repo has diverged from upstream cause the public source got force pushed.