### PR TITLE
ci: cargo audit hard gate

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,20 +1,31 @@
 # cargo-audit configuration for Gork Build.
 #
-# CI treats audit as a **hard gate**: any vulnerability not listed here fails
-# the job. Entries below are residual issues in the upstream monorepo graph
-# that cannot be fixed with a clean lockfile bump alone (pinned transitive
-# majors, or no fixed release). Revisit when upstream or direct deps update.
+# CI treats audit as a **hard gate**: any vulnerability *not* listed here fails
+# the job. This is "block new unignored vulns", not "tree is clean".
 #
+# Config path: `.cargo/audit.toml` (cargo-audit project discovery).
 # See: https://docs.rs/cargo-audit/latest/cargo_audit/
 
 [advisories]
-# rsa: RUSTSEC-2023-0071 Marvin Attack — no fixed upgrade from the crate author.
-# Pulled via jsonwebtoken / sigstore stack; accept until those crates migrate.
 ignore = [
+    # --- RUSTSEC-2023-0071 (rsa, Marvin Attack) ---
+    # Package: rsa (no fixed upgrade on crates.io as of 2026-07).
+    # Dependency chain: rsa ← jsonwebtoken / sigstore-* (via xai-grok-shell graph).
+    # Why ignore: RustSec marks no patched version; only full stack migration
+    #   away from `rsa` crate removes the finding.
+    # Remove when: jsonwebtoken/sigstore (or our fork pins) drop `rsa`, or
+    #   RUSTSEC-2023-0071 gains a fixed release we can lock to.
     "RUSTSEC-2023-0071",
-    # quick-xml: needs >=0.41; direct pin is ^0.38 (xai-grok-tools) and
-    # pdf_oxide pins ^0.39. Bump requires coordinated API changes — track
-    # separately; not a silent ignore of new advisories on other crates.
+
+    # --- RUSTSEC-2026-0194 / RUSTSEC-2026-0195 (quick-xml DoS) ---
+    # Package: quick-xml < 0.41.0
+    # Dependency chain:
+    #   quick-xml ^0.38 ← xai-grok-tools (direct)
+    #   quick-xml ^0.39 ← pdf_oxide ← xai-grok-tools
+    # Why ignore: fix requires >=0.41; cannot cargo-update without bumping
+    #   xai-grok-tools / pdf_oxide API major pins (coordinated change).
+    # Remove when: xai-grok-tools + pdf_oxide accept quick-xml >=0.41 and
+    #   Cargo.lock is refreshed accordingly. Track: follow-up dep-bump PR.
     "RUSTSEC-2026-0194",
     "RUSTSEC-2026-0195",
 ]

--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,20 @@
+# cargo-audit configuration for Gork Build.
+#
+# CI treats audit as a **hard gate**: any vulnerability not listed here fails
+# the job. Entries below are residual issues in the upstream monorepo graph
+# that cannot be fixed with a clean lockfile bump alone (pinned transitive
+# majors, or no fixed release). Revisit when upstream or direct deps update.
+#
+# See: https://docs.rs/cargo-audit/latest/cargo_audit/
+
+[advisories]
+# rsa: RUSTSEC-2023-0071 Marvin Attack — no fixed upgrade from the crate author.
+# Pulled via jsonwebtoken / sigstore stack; accept until those crates migrate.
+ignore = [
+    "RUSTSEC-2023-0071",
+    # quick-xml: needs >=0.41; direct pin is ^0.38 (xai-grok-tools) and
+    # pdf_oxide pins ^0.39. Bump requires coordinated API changes — track
+    # separately; not a silent ignore of new advisories on other crates.
+    "RUSTSEC-2026-0194",
+    "RUSTSEC-2026-0195",
+]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,10 +127,12 @@ jobs:
           cargo test -p xai-grok-telemetry --lib default_is_privacy
           # Updater hard-off: bottom chokepoint, leader ensure_latest, manual
           # update, status/background, minimum-version refuse vendor install.
+          # Without --features updater-integration-tests: proves product path
+          # has no env escape hatch (including GORK_TEST_ALLOW_UPDATE=1).
           cargo test -p xai-grok-update --lib privacy -- --nocapture
+          cargo test -p xai-grok-update --lib env_cannot_disable -- --nocapture
           cargo test -p xai-grok-update --lib reinstall_hint -- --nocapture
           cargo test -p xai-grok-update --lib refuses_minimum -- --nocapture
-          cargo test -p xai-grok-update --lib test_escape_hatch -- --nocapture
           # Telemetry / trace resolvers: env/config/remote cannot re-enable.
           # Integration test (not --lib): full shell unit tests fail upstream
           # (missing WorkspaceOps::for_test helpers); this binary drives the

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,7 +95,8 @@ jobs:
   test-privacy:
     name: Privacy tests
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    # Full update suite + feature-enabled installer tests can be slow.
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@v7
 
@@ -125,18 +126,18 @@ jobs:
           cargo test -p xai-grok-version --lib
           cargo test -p xai-mixpanel --lib
           cargo test -p xai-grok-telemetry --lib default_is_privacy
-          # Updater hard-off: bottom chokepoint, leader ensure_latest, manual
-          # update, status/background, minimum-version refuse vendor install.
-          # Without --features updater-integration-tests: proves product path
-          # has no env escape hatch (including GORK_TEST_ALLOW_UPDATE=1).
+          # Default product build: full update crate suite (lib + integration
+          # tests that do NOT require installer mocks). Installer-mechanic
+          # tests are behind `updater-integration-tests` and compile empty
+          # without the feature.
+          cargo test -p xai-grok-update
+          # Focused privacy filters (also covered above; keep for clarity).
           cargo test -p xai-grok-update --lib privacy -- --nocapture
           cargo test -p xai-grok-update --lib env_cannot_disable -- --nocapture
-          cargo test -p xai-grok-update --lib reinstall_hint -- --nocapture
-          cargo test -p xai-grok-update --lib refuses_minimum -- --nocapture
+          # Installer mechanics against local mocks (feature + env required).
+          GORK_TEST_ALLOW_UPDATE=1 cargo test -p xai-grok-update \
+            --features updater-integration-tests --tests
           # Telemetry / trace resolvers: env/config/remote cannot re-enable.
-          # Integration test (not --lib): full shell unit tests fail upstream
-          # (missing WorkspaceOps::for_test helpers); this binary drives the
-          # shipped Config resolvers without those helpers.
           cargo test -p xai-grok-shell --test privacy_resolvers -- --nocapture
 
       - name: Static install chokepoint inventory

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,7 +120,8 @@ jobs:
         run: |
           # Crates that compile cleanly as lib tests in the open-source
           # snapshot. Full xai-grok-shell --lib currently fails upstream
-          # (missing test helpers / partial monorepo cut).
+          # (missing test helpers / partial monorepo cut) — so we filter to
+          # privacy resolver tests that do compile when the crate builds.
           cargo test -p xai-grok-version --lib
           cargo test -p xai-mixpanel --lib
           cargo test -p xai-grok-telemetry --lib default_is_privacy
@@ -129,6 +130,12 @@ jobs:
           cargo test -p xai-grok-update --lib privacy -- --nocapture
           cargo test -p xai-grok-update --lib reinstall_hint -- --nocapture
           cargo test -p xai-grok-update --lib refuses_minimum -- --nocapture
+          cargo test -p xai-grok-update --lib test_escape_hatch -- --nocapture
+          # Telemetry / trace resolvers: env/config/remote cannot re-enable.
+          # Integration test (not --lib): full shell unit tests fail upstream
+          # (missing WorkspaceOps::for_test helpers); this binary drives the
+          # shipped Config resolvers without those helpers.
+          cargo test -p xai-grok-shell --test privacy_resolvers -- --nocapture
 
       - name: Static install chokepoint inventory
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,13 +118,57 @@ jobs:
 
       - name: Test privacy-critical crates
         run: |
-          # Keep this list to crates that compile cleanly as lib tests in the
-          # open-source snapshot. Full xai-grok-shell --lib currently fails
-          # upstream (missing test helpers / partial monorepo cut).
+          # Crates that compile cleanly as lib tests in the open-source
+          # snapshot. Full xai-grok-shell --lib currently fails upstream
+          # (missing test helpers / partial monorepo cut).
           cargo test -p xai-grok-version --lib
           cargo test -p xai-mixpanel --lib
           cargo test -p xai-grok-telemetry --lib default_is_privacy
-          cargo test -p xai-grok-update --lib test_reinstall_hint -- --nocapture
+          # Updater hard-off: bottom chokepoint, leader ensure_latest, manual
+          # update, status/background, minimum-version refuse vendor install.
+          cargo test -p xai-grok-update --lib privacy -- --nocapture
+          cargo test -p xai-grok-update --lib reinstall_hint -- --nocapture
+          cargo test -p xai-grok-update --lib refuses_minimum -- --nocapture
+
+      - name: Static install chokepoint inventory
+        run: |
+          set -euo pipefail
+          # Product install entry must gate on vendor_auto_update_forbidden.
+          grep -n 'vendor_auto_update_forbidden' \
+            crates/codegen/xai-grok-update/src/auto_update.rs \
+            crates/codegen/xai-grok-update/src/minimum_version.rs
+          # run_install_script must contain the privacy early return.
+          grep -n 'if vendor_auto_update_forbidden' \
+            crates/codegen/xai-grok-update/src/auto_update.rs
+          # Default internal bases must still be the vendor CDN (so the gate
+          # is what blocks them — not a silent empty list).
+          grep -n 'https://x.ai/cli' crates/codegen/xai-grok-update/src/version.rs
+
+  # Optional supply-chain scan (advisory DB; non-blocking until the fork
+  # pins deny.toml / allowlists for the full monorepo graph).
+  cargo-audit:
+    name: cargo audit (informational)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v7
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ env.RUST_TOOLCHAIN }}
+      - name: Install cargo-audit
+        run: cargo install cargo-audit --locked
+      - name: cargo audit
+        run: cargo audit 2>&1 | tee cargo-audit.log || true
+      - name: Upload audit log
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: cargo-audit-log
+          path: cargo-audit.log
+          if-no-files-found: ignore
+          retention-days: 14
 
   # ── Build ─────────────────────────────────────────────────────────────────
   build-gork:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,8 +134,17 @@ jobs:
           cargo test -p xai-grok-update --lib privacy -- --nocapture
           cargo test -p xai-grok-update --lib env_cannot_disable -- --nocapture
           # Installer mechanics against local mocks (feature + env required).
+          # IMPORTANT: cargo's `--tests` also runs library unit tests. With the
+          # feature compiled in and GORK_TEST_ALLOW_UPDATE=1 in the process
+          # env, privacy unit tests that assert "gate stays on" would fail.
+          # Target only the installer integration test binaries by name.
           GORK_TEST_ALLOW_UPDATE=1 cargo test -p xai-grok-update \
-            --features updater-integration-tests --tests
+            --features updater-integration-tests \
+            --test test_install_internal \
+            --test test_blitz_cancel \
+            --test test_check_status_regression \
+            --test test_concurrent_convergence \
+            --test test_downgrade_matrix
           # Telemetry / trace resolvers: env/config/remote cannot re-enable.
           cargo test -p xai-grok-shell --test privacy_resolvers -- --nocapture
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,6 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,13 +162,12 @@ jobs:
           # is what blocks them — not a silent empty list).
           grep -n 'https://x.ai/cli' crates/codegen/xai-grok-update/src/version.rs
 
-  # Optional supply-chain scan (advisory DB; non-blocking until the fork
-  # pins deny.toml / allowlists for the full monorepo graph).
+  # Supply-chain hard gate: fails on any vulnerability not ignored in audit.toml.
+  # Ignore list is residual monorepo debt (rsa unfixed; quick-xml major pin).
   cargo-audit:
-    name: cargo audit (informational)
+    name: cargo audit
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    continue-on-error: true
     steps:
       - uses: actions/checkout@v7
       - name: Install Rust toolchain
@@ -177,8 +176,13 @@ jobs:
           toolchain: ${{ env.RUST_TOOLCHAIN }}
       - name: Install cargo-audit
         run: cargo install cargo-audit --locked
-      - name: cargo audit
-        run: cargo audit 2>&1 | tee cargo-audit.log || true
+      - name: cargo audit (hard gate)
+        run: |
+          set -euo pipefail
+          # Fail on unignored vulnerabilities. Unmaintained/unsound/yanked
+          # packages are warned by default; do not use --deny warnings yet
+          # (large monorepo has residual unmaintained transitive crates).
+          cargo audit 2>&1 | tee cargo-audit.log
       - name: Upload audit log
         if: always()
         uses: actions/upload-artifact@v7

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -300,7 +300,7 @@ dependencies = [
  "objc2-foundation 0.3.2",
  "parking_lot",
  "percent-encoding",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
  "wl-clipboard-rs",
  "x11rb",
 ]
@@ -2192,9 +2192,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -2210,9 +2210,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.21"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
 name = "crossterm"
@@ -2693,7 +2693,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3025,7 +3025,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6467,7 +6467,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7080,7 +7080,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -8028,9 +8028,9 @@ dependencies = [
 
 [[package]]
 name = "quinn"
-version = "0.11.9"
+version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
 dependencies = [
  "bytes",
  "cfg_aliases 0.2.1",
@@ -8048,9 +8048,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "aws-lc-rs",
  "bytes",
@@ -8079,7 +8079,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8724,7 +8724,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8794,7 +8794,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -10137,7 +10137,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -11951,7 +11951,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -14,10 +14,11 @@ and config files **cannot** re-enable them while
 `xai_grok_version::PRIVACY_BUILD == true` (including product telemetry
 env vars such as `GROK_TELEMETRY_*` and vendor update settings).
 
-**Residual (debug/test only):** debug-profile builds of the updater crate
-may honor `GORK_TEST_ALLOW_UPDATE=1` so integration tests can exercise
-local mock installers. **Release product binaries ignore that variable
-entirely** (`cfg(debug_assertions)` gate). Never set it outside tests.
+**Installer integration tests only:** the optional Cargo feature
+`updater-integration-tests` (never enabled by `cargo run` / product builds)
+plus `GORK_TEST_ALLOW_UPDATE=1` can relax the vendor-update gate so local
+mock download suites work. That feature is not part of any product binary;
+ordinary debug and release builds have no runtime escape hatch.
 
 1. **Research / trace uploads** — `resolve_trace_upload()` always returns
    `false`. `get_trace_context` never builds an upload method for GCS session
@@ -36,8 +37,8 @@ entirely** (`cfg(debug_assertions)` gate). Never set it outside tests.
    update and minimum-version enforcement also **fail closed** under the
    privacy build — they refuse vendor install rather than overwrite the binary.
    Update by rebuilding from this repository or community releases.
-   Release builds cannot re-enable vendor install via env (see residual note
-   above for the debug-only test hook).
+   Product binaries (debug or release) cannot re-enable vendor install via
+   env; see the test-only Cargo feature note above.
 6. **Sentry** — no compile-time DSN; only an explicit runtime `SENTRY_DSN`
    can enable crash reporting.
 

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -11,7 +11,13 @@ Background (why the hard-offs exist):
 
 These are compile-time / resolver-level hard-offs. Remote settings, env vars,
 and config files **cannot** re-enable them while
-`xai_grok_version::PRIVACY_BUILD == true`.
+`xai_grok_version::PRIVACY_BUILD == true` (including product telemetry
+env vars such as `GROK_TELEMETRY_*` and vendor update settings).
+
+**Residual (debug/test only):** debug-profile builds of the updater crate
+may honor `GORK_TEST_ALLOW_UPDATE=1` so integration tests can exercise
+local mock installers. **Release product binaries ignore that variable
+entirely** (`cfg(debug_assertions)` gate). Never set it outside tests.
 
 1. **Research / trace uploads** — `resolve_trace_upload()` always returns
    `false`. `get_trace_context` never builds an upload method for GCS session
@@ -30,6 +36,8 @@ and config files **cannot** re-enable them while
    update and minimum-version enforcement also **fail closed** under the
    privacy build — they refuse vendor install rather than overwrite the binary.
    Update by rebuilding from this repository or community releases.
+   Release builds cannot re-enable vendor install via env (see residual note
+   above for the debug-only test hook).
 6. **Sentry** — no compile-time DSN; only an explicit runtime `SENTRY_DSN`
    can enable crash reporting.
 

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -23,9 +23,13 @@ and config files **cannot** re-enable them while
    no-ops if anything still calls them.
 4. **Repo change packaging** — `[repo_changes_dedup] enabled` defaults to
    `false`.
-5. **Vendor auto-update** — hard-disabled. Gork Build never runs
-   `x.ai/cli/install.*`; that channel would replace this fork with official
-   Grok Build. Update by rebuilding from this repository.
+5. **Vendor auto-update** — hard-disabled. Gork Build never installs from
+   x.ai update channels (`x.ai/cli/install.*`); that path would replace this
+   fork with official Grok Build. Policy is enforced at the bottom-level
+   chokepoint `run_install_script` (and every caller of it). Leader hourly
+   update and minimum-version enforcement also **fail closed** under the
+   privacy build — they refuse vendor install rather than overwrite the binary.
+   Update by rebuilding from this repository or community releases.
 6. **Sentry** — no compile-time DSN; only an explicit runtime `SENTRY_DSN`
    can enable crash reporting.
 
@@ -44,12 +48,29 @@ That is inference context, not Gork Build research upload. Prefer not opening
 `.env` / key material in the session; secret redaction exists for some
 telemetry paths but is not a complete guarantee on the model path.
 
-The README claim
-“[no secrets send to xAI](https://gist.github.com/cereblab/dc9a40bc26120f4540e4e09b75ffb547)”
-refers to **not packaging research traces / whole-repo uploads / product
-analytics** that were shown to exfiltrate secrets in the wire analysis. It
-does **not** mean the model never sees file contents you ask the agent to
+Research / product-analytics hard-offs stop packaging of session traces,
+whole-repo research uploads, and Mixpanel-style events shown in the
+[wire analysis](https://gist.github.com/cereblab/dc9a40bc26120f4540e4e09b75ffb547).
+They do **not** mean the model never sees file contents you ask the agent to
 read — that is still how cloud coding works.
+
+## Network egress inventory
+
+Channels the binary *can* touch, and how Gork Build treats them:
+
+| Channel | Default in this build | Notes |
+|---------|----------------------|--------|
+| **Model API** (cli-chat-proxy / `/v1/responses` etc.) | On when you use the agent | Agent-selected context (prompts, tools, file contents read for the task) goes here — required for cloud coding |
+| **Auth** (OIDC / login) | On when you sign in | Credentials / tokens for your account |
+| **Remote settings / managed config** | May fetch when configured | Feature/config pull; cannot re-enable research or product telemetry hard-offs |
+| **Model catalog** | May fetch when listing models | Model metadata for the picker |
+| **Assets** (themes, announcements, static assets) | Optional / as needed | Non-secret presentation content |
+| **Feedback** | User-initiated only | Only if you explicitly submit feedback |
+| **External OTLP** | Off unless you configure an exporter | Product telemetry mode is hard-`Disabled`; custom OTLP is user opt-in |
+| **Sentry** | Off | Only if you set `SENTRY_DSN` |
+| **MCP / plugins** | Off until you enable | User-configured servers and marketplaces you add |
+| **Web search** | Off until you enable | Tool you turn on for the agent |
+| **Update metadata / install** | Vendor install **hard-off** | No `x.ai/cli` install scripts; `run_install_script` fail-closed; leader + minimum-version refuse vendor overwrite. Rebuild from source or community releases |
 
 ## Server-side retention
 

--- a/README.md
+++ b/README.md
@@ -10,11 +10,17 @@
   Gork Build (<code>gork</code>)
 </h1>
 
-**Gork Build: the VSCodium-style community build of Grok Build, [no secrets send to xAI](https://gist.github.com/cereblab/dc9a40bc26120f4540e4e09b75ffb547)**
+**Gork Build: the VSCodium-style community build of Grok Build — [research / product analytics hard-off](https://gist.github.com/cereblab/dc9a40bc26120f4540e4e09b75ffb547)**
 
 An independent, community-maintained distribution of
 [SpaceXAI Grok Build](https://github.com/xai-org/grok-build) with vendor
-telemetry and branding removed.
+telemetry hard-off and a community rebrand (compatibility identifiers such as
+`~/.grok`, `GROK_*`, and API hosts are retained).
+
+**Privacy note:** agent-selected model context (prompts, tool results, file
+contents the agent reads) still goes to the model API — that is how cloud
+coding works. Research uploads and product analytics are hard-off separately;
+they are not the same channel.
 
 [Building from source](#build-from-source) ·
 [Privacy](#privacy-guarantees-client) ·
@@ -29,7 +35,8 @@ telemetry and branding removed.
 
 This repository contains the Rust source for the `gork` CLI/TUI and agent
 runtime, forked from [`xai-org/grok-build`](https://github.com/xai-org/grok-build)
-with research telemetry hard-off and vendor branding removed.
+with research telemetry hard-off and a community rebrand (paths, env prefixes,
+and API hosts kept for compatibility).
 
 </div>
 
@@ -45,7 +52,7 @@ Comparison at a glance:
 | Mixpanel / product events | On by default in releases | **Hard-off** |
 | GCS research / session traces | Upload pipeline present | **Hard-off** |
 | Whole-repo research packaging | Present upstream | **Disabled** |
-| Auto-update | Yes | **No** |
+| Vendor auto-update | Yes (`x.ai/cli`) | **Hard-disabled** (rebuild / community releases) |
 | Coding-data retention | Opt-in available | **Opt-out only (locked)** |
 
 ---
@@ -62,17 +69,16 @@ including secrets in files the agent read. Upstream open-sourced the harness;
 - No client-side research / trace / session-state uploads to GCS
 - Remote feature flags **cannot** re-enable those paths
 - Coding-data retention is **opt-out only** (no opt-in path)
-- No vendor auto-update: Gork Build never runs `x.ai/cli/install.*` (that
-  would replace your binary with official Grok Build)
+- Vendor auto-update is **hard-disabled**: Gork Build never installs from
+  x.ai update channels (`x.ai/cli/install.*`); that path would replace this
+  fork with official Grok Build. Update by rebuilding from source or installing
+  community releases from **this** project.
 
 **What still leaves the machine:** whatever the agent must send to the Grok
 **model API** to work (prompts + tool results for files it actually reads).
-That is required for a cloud coding agent. Gork Build does not add extra
-research packaging on top.
-
-**How to update Gork Build:** pull this repository and rebuild (or install a
-release from **this** project when published). There is no shared update
-channel with upstream.
+That is required for a cloud coding agent and is separate from the research /
+product-analytics hard-offs. Gork Build does not add extra research packaging
+on top.
 
 ## Build from source
 
@@ -98,7 +104,7 @@ upstream does — model access still goes through the Grok API.
 | `POST …/v1/storage` research traces | **Never enabled** (`resolve_trace_upload` → false) |
 | Mixpanel / product events | **No-op / never constructed** |
 | Sentry | Only if you set `SENTRY_DSN` yourself |
-| Vendor auto-update (`x.ai/cli/install.*`) | **Never** (would overwrite the fork) |
+| Vendor auto-update (`x.ai/cli/install.*`) | **Hard-disabled** — rebuild from source / community releases |
 | `is_data_collection_disabled` | Always **true** in this build |
 
 See [`PRIVACY.md`](PRIVACY.md) for details and residual risks.
@@ -115,8 +121,9 @@ trace_upload = false
 mixpanel_enabled = false
 ```
 
-`[cli] auto_update` is ignored for vendor channels: this build will not fetch
-or run x.ai installers even if the key is set to `true`.
+`[cli] auto_update` cannot re-enable vendor channels: this build never installs
+from x.ai (enforced at the install chokepoint). Rebuild from source or use
+community releases.
 
 ## Documentation
 

--- a/crates/codegen/xai-grok-shell/src/agent/config.rs
+++ b/crates/codegen/xai-grok-shell/src/agent/config.rs
@@ -2054,7 +2054,8 @@ impl Config {
     pub fn is_two_pass_compaction_enabled(&self) -> bool {
         self.resolve_two_pass_compaction().value
     }
-    pub(crate) fn resolve_telemetry_mode(&self) -> Resolved<TelemetryMode> {
+    /// Resolve effective product telemetry mode (Gork Build: always Disabled).
+    pub fn resolve_telemetry_mode(&self) -> Resolved<TelemetryMode> {
         // Gork Build: product telemetry is permanently off (remote/env cannot
         // re-enable Mixpanel / events / research metrics).
         if xai_grok_version::research_data_collection_forbidden() {
@@ -2081,7 +2082,8 @@ impl Config {
         }
         Resolved::new(TelemetryMode::Disabled, ConfigSource::Default)
     }
-    pub(crate) fn resolve_trace_upload(&self) -> Resolved<bool> {
+    /// Resolve whether session/repo research trace upload is enabled (Gork Build: always false).
+    pub fn resolve_trace_upload(&self) -> Resolved<bool> {
         // Gork Build: never upload session/repo traces to GCS (or anywhere).
         if xai_grok_version::research_data_collection_forbidden() {
             return Resolved::new(false, ConfigSource::Default);
@@ -8106,6 +8108,19 @@ reasoning_effort = "low"
     #[test]
     #[serial]
     fn resolve_trace_upload_explicit_config_wins_over_telemetry_off() {
+        // Under Gork Build privacy, hard-off short-circuits before config/env.
+        if xai_grok_version::research_data_collection_forbidden() {
+            unsafe { std::env::remove_var("GROK_TELEMETRY_ENABLED") };
+            unsafe { std::env::remove_var("GROK_TELEMETRY_TRACE_UPLOAD") };
+            let mut cfg = Config::default();
+            cfg.features.telemetry = Some(TelemetryMode::Disabled);
+            cfg.telemetry.trace_upload = Some(true);
+            assert!(
+                !cfg.resolve_trace_upload().value,
+                "privacy hard-off must win over explicit trace_upload=true"
+            );
+            return;
+        }
         unsafe { std::env::remove_var("GROK_TELEMETRY_ENABLED") };
         unsafe { std::env::remove_var("GROK_TELEMETRY_TRACE_UPLOAD") };
         let mut cfg = Config::default();
@@ -8136,19 +8151,46 @@ reasoning_effort = "low"
         });
         let d = cfg.trace_upload_decision_debug();
         assert_eq!(d["trace_upload"], serde_json::json!(false));
+        // Privacy short-circuit reports default; non-privacy also forces false
+        // when telemetry is off despite remote flag.
         assert_eq!(d["trace_upload_source"], serde_json::json!("default"));
         assert_eq!(d["telemetry_mode"], serde_json::json!("false"));
         assert_eq!(d["in_remote_trace_upload_enabled"], serde_json::json!(true));
         assert_eq!(d["has_remote_settings"], serde_json::json!(true));
         cfg.telemetry.trace_upload = Some(true);
         let d = cfg.trace_upload_decision_debug();
-        assert_eq!(d["trace_upload"], serde_json::json!(true));
-        assert_eq!(d["trace_upload_source"], serde_json::json!("config"));
-        assert_eq!(d["in_cfg_telemetry_trace_upload"], serde_json::json!(true));
+        if xai_grok_version::research_data_collection_forbidden() {
+            assert_eq!(
+                d["trace_upload"],
+                serde_json::json!(false),
+                "privacy hard-off must keep debug decision false"
+            );
+        } else {
+            assert_eq!(d["trace_upload"], serde_json::json!(true));
+            assert_eq!(d["trace_upload_source"], serde_json::json!("config"));
+            assert_eq!(d["in_cfg_telemetry_trace_upload"], serde_json::json!(true));
+        }
     }
     #[test]
     #[serial]
     fn resolve_trace_upload_honors_config_when_telemetry_on() {
+        // Under Gork Build privacy, the hard-off short-circuit wins first.
+        // Non-privacy (upstream) semantics: explicit false config wins; when
+        // telemetry is fully enabled and trace_upload is unset, default is on.
+        if xai_grok_version::research_data_collection_forbidden() {
+            unsafe { std::env::remove_var("GROK_TELEMETRY_ENABLED") };
+            unsafe { std::env::remove_var("GROK_TELEMETRY_TRACE_UPLOAD") };
+            let mut cfg = Config::default();
+            cfg.features.telemetry = Some(TelemetryMode::Enabled);
+            cfg.telemetry.trace_upload = Some(false);
+            assert!(!cfg.resolve_trace_upload().value);
+            cfg.telemetry.trace_upload = None;
+            assert!(
+                !cfg.resolve_trace_upload().value,
+                "privacy hard-off: cannot default-on trace upload"
+            );
+            return;
+        }
         unsafe { std::env::remove_var("GROK_TELEMETRY_ENABLED") };
         unsafe { std::env::remove_var("GROK_TELEMETRY_TRACE_UPLOAD") };
         let mut cfg = Config::default();
@@ -8161,6 +8203,76 @@ reasoning_effort = "low"
         let r = cfg.resolve_trace_upload();
         assert!(r.value, "defaults on when telemetry fully enabled");
     }
+
+    /// Criterion 2: privacy build hard-offs cannot be re-enabled via env, config,
+    /// requirements pin, or remote settings. Drives the real resolvers.
+    #[test]
+    #[serial]
+    fn privacy_build_telemetry_mode_ignores_env_config_and_remote() {
+        assert!(
+            xai_grok_version::research_data_collection_forbidden(),
+            "this fork must lock research collection off"
+        );
+        // SAFETY: #[serial]
+        unsafe {
+            std::env::set_var("GROK_TELEMETRY_ENABLED", "1");
+        }
+        let mut cfg = Config::default();
+        cfg.features.telemetry = Some(TelemetryMode::Enabled);
+        cfg.requirements.telemetry.pin(
+            TelemetryMode::Enabled,
+            crate::config::RequirementSource::Unknown,
+        );
+        cfg.remote_settings = Some(crate::util::config::RemoteSettings {
+            telemetry_enabled: Some(true),
+            telemetry_mode: Some("enabled".into()),
+            ..Default::default()
+        });
+        let r = cfg.resolve_telemetry_mode();
+        assert!(
+            r.value.is_disabled(),
+            "privacy hard-off must win over env/config/remote: {:?}",
+            r
+        );
+        unsafe {
+            std::env::remove_var("GROK_TELEMETRY_ENABLED");
+        }
+    }
+
+    #[test]
+    #[serial]
+    fn privacy_build_trace_upload_ignores_env_config_and_remote() {
+        assert!(xai_grok_version::research_data_collection_forbidden());
+        // SAFETY: #[serial]
+        unsafe {
+            std::env::set_var("GROK_TELEMETRY_ENABLED", "1");
+            std::env::set_var("GROK_TELEMETRY_TRACE_UPLOAD", "1");
+        }
+        let mut cfg = Config::default();
+        cfg.features.telemetry = Some(TelemetryMode::Enabled);
+        cfg.telemetry.trace_upload = Some(true);
+        cfg.requirements
+            .trace_upload
+            .pin(true, crate::config::RequirementSource::Unknown);
+        cfg.remote_settings = Some(crate::util::config::RemoteSettings {
+            telemetry_enabled: Some(true),
+            telemetry_mode: Some("enabled".into()),
+            trace_upload_enabled: Some(true),
+            ..Default::default()
+        });
+        let r = cfg.resolve_trace_upload();
+        assert!(
+            !r.value,
+            "privacy hard-off must win over env/config/remote for trace upload: {:?}",
+            r
+        );
+        assert!(!cfg.is_trace_upload_enabled());
+        unsafe {
+            std::env::remove_var("GROK_TELEMETRY_ENABLED");
+            std::env::remove_var("GROK_TELEMETRY_TRACE_UPLOAD");
+        }
+    }
+
     #[test]
     #[serial]
     fn resolve_goal_defaults_to_true_when_unset() {

--- a/crates/codegen/xai-grok-shell/tests/privacy_resolvers.rs
+++ b/crates/codegen/xai-grok-shell/tests/privacy_resolvers.rs
@@ -1,0 +1,79 @@
+//! Privacy hard-off regression tests for telemetry / trace-upload resolvers.
+//!
+//! Integration tests (not `#[cfg(test)]` unit tests) so they compile against the
+//! normal shell library — full `xai-grok-shell --lib` unit tests currently fail
+//! upstream due to missing test helpers.
+//!
+//! These drive the **shipped** `Config::resolve_telemetry_mode` /
+//! `resolve_trace_upload` entry points with env, config, and remote settings
+//! that would re-enable product telemetry on upstream Grok Build.
+
+use serial_test::serial;
+use xai_grok_config_types::RemoteSettings;
+use xai_grok_shell::agent::config::{Config, TelemetryMode};
+
+#[test]
+#[serial]
+fn privacy_build_telemetry_mode_ignores_env_config_and_remote() {
+    assert!(
+        xai_grok_version::research_data_collection_forbidden(),
+        "this fork must lock research collection off"
+    );
+    // SAFETY: #[serial]
+    unsafe {
+        std::env::set_var("GROK_TELEMETRY_ENABLED", "1");
+    }
+    let mut cfg = Config::default();
+    cfg.features.telemetry = Some(TelemetryMode::Enabled);
+    cfg.requirements.telemetry.pin(
+        TelemetryMode::Enabled,
+        xai_grok_shell::config::RequirementSource::Unknown,
+    );
+    cfg.remote_settings = Some(RemoteSettings {
+        telemetry_enabled: Some(true),
+        telemetry_mode: Some("enabled".into()),
+        ..Default::default()
+    });
+    let r = cfg.resolve_telemetry_mode();
+    assert!(
+        r.value.is_disabled(),
+        "privacy hard-off must win over env/config/remote: mode={:?}",
+        r.value
+    );
+    unsafe {
+        std::env::remove_var("GROK_TELEMETRY_ENABLED");
+    }
+}
+
+#[test]
+#[serial]
+fn privacy_build_trace_upload_ignores_env_config_and_remote() {
+    assert!(xai_grok_version::research_data_collection_forbidden());
+    // SAFETY: #[serial]
+    unsafe {
+        std::env::set_var("GROK_TELEMETRY_ENABLED", "1");
+        std::env::set_var("GROK_TELEMETRY_TRACE_UPLOAD", "1");
+    }
+    let mut cfg = Config::default();
+    cfg.features.telemetry = Some(TelemetryMode::Enabled);
+    cfg.telemetry.trace_upload = Some(true);
+    cfg.requirements
+        .trace_upload
+        .pin(true, xai_grok_shell::config::RequirementSource::Unknown);
+    cfg.remote_settings = Some(RemoteSettings {
+        telemetry_enabled: Some(true),
+        telemetry_mode: Some("enabled".into()),
+        trace_upload_enabled: Some(true),
+        ..Default::default()
+    });
+    let r = cfg.resolve_trace_upload();
+    assert!(
+        !r.value,
+        "privacy hard-off must win over env/config/remote for trace upload"
+    );
+    assert!(!cfg.is_trace_upload_enabled());
+    unsafe {
+        std::env::remove_var("GROK_TELEMETRY_ENABLED");
+        std::env::remove_var("GROK_TELEMETRY_TRACE_UPLOAD");
+    }
+}

--- a/crates/codegen/xai-grok-update/Cargo.toml
+++ b/crates/codegen/xai-grok-update/Cargo.toml
@@ -4,6 +4,13 @@ name = "xai-grok-update"
 version = "0.1.220-alpha.4"
 edition.workspace = true
 
+[features]
+default = []
+# Enables the `GORK_TEST_ALLOW_UPDATE=1` escape hatch for local mock installer
+# integration tests only. Never enabled by product binaries / `cargo run` /
+# default `cargo build`. Privacy hard-off cannot be disabled without this feature.
+updater-integration-tests = []
+
 [dependencies]
 anyhow = { workspace = true }
 futures = { workspace = true }

--- a/crates/codegen/xai-grok-update/src/auto_update.rs
+++ b/crates/codegen/xai-grok-update/src/auto_update.rs
@@ -44,12 +44,10 @@ fn reinstall_hint(installer: &str) -> String {
     }
 }
 
-/// Env var that **debug-profile integration tests** may set to `"1"` so local
-/// mock installer suites can exercise download/swap mechanics.
-///
-/// **Release product binaries ignore this entirely** (`cfg(debug_assertions)`
-/// only). Even in debug, only the exact value `"1"` relaxes the gate — empty
-/// or other values do not.
+/// Env var used **only** when the crate is built with
+/// `--features updater-integration-tests`. Product builds never compile the
+/// escape path, so `cargo run` / release binaries cannot disable the gate.
+#[cfg(feature = "updater-integration-tests")]
 const TEST_ALLOW_UPDATE_ENV: &str = "GORK_TEST_ALLOW_UPDATE";
 
 /// Gork Build never auto-updates from vendor (x.ai) channels. Enabling that
@@ -59,15 +57,14 @@ const TEST_ALLOW_UPDATE_ENV: &str = "GORK_TEST_ALLOW_UPDATE";
 /// Callers must check it, and [`run_install_script`] enforces it as the
 /// last line of defense.
 ///
-/// Debug-only test hook: when built with `debug_assertions` and
-/// `GORK_TEST_ALLOW_UPDATE=1`, the gate is relaxed for crate integration
-/// tests against local fake servers. **Release builds never honor the env
-/// var** — privacy hard-off cannot be re-enabled at runtime in product
-/// binaries.
+/// **No runtime escape hatch in product builds.** The only way to relax this
+/// for local mock installer tests is to compile with the
+/// `updater-integration-tests` feature *and* set `GORK_TEST_ALLOW_UPDATE=1`.
+/// Ordinary `cargo build` / `cargo run` / release builds do not include that
+/// path at all.
 #[inline]
 pub fn vendor_auto_update_forbidden() -> bool {
-    // Release product paths: always honor privacy. No env re-enable.
-    #[cfg(debug_assertions)]
+    #[cfg(feature = "updater-integration-tests")]
     {
         if std::env::var(TEST_ALLOW_UPDATE_ENV).as_deref() == Ok("1") {
             return false;
@@ -2240,8 +2237,8 @@ pub async fn run_update(
     update_config: &mut UpdateConfig,
 ) -> Result<Option<String>> {
     // Manual `gork update` must not pull vendor binaries either.
+    // Message is on the error only (avoid double-print via eprintln + Err).
     if vendor_auto_update_forbidden() {
-        eprintln!("{}", vendor_update_blocked_message());
         return Err(vendor_update_blocked_err());
     }
     apply_channel_switch(channel_switch, update_config).await;
@@ -3343,25 +3340,9 @@ mod tests {
 
     // ──────────────────────────────────────────────────────────────────────
     // Privacy / vendor-update hard-off (Gork Build)
+    // Default product builds (no `updater-integration-tests` feature) never
+    // honor GORK_TEST_ALLOW_UPDATE — even if the env var is present.
     // ──────────────────────────────────────────────────────────────────────
-
-    fn privacy_gate_guard() -> (Option<std::ffi::OsString>,) {
-        let allow = std::env::var_os(TEST_ALLOW_UPDATE_ENV);
-        // SAFETY: unit tests that touch this env are #[serial].
-        unsafe {
-            std::env::remove_var(TEST_ALLOW_UPDATE_ENV);
-        }
-        (allow,)
-    }
-
-    fn privacy_gate_restore(allow: Option<std::ffi::OsString>) {
-        unsafe {
-            match allow {
-                Some(v) => std::env::set_var(TEST_ALLOW_UPDATE_ENV, v),
-                None => std::env::remove_var(TEST_ALLOW_UPDATE_ENV),
-            }
-        }
-    }
 
     fn dummy_update_config() -> UpdateConfig {
         UpdateConfig {
@@ -3375,9 +3356,7 @@ mod tests {
     }
 
     #[test]
-    #[serial_test::serial]
     fn privacy_build_forbids_vendor_auto_update() {
-        let (allow,) = privacy_gate_guard();
         assert!(
             vendor_auto_update_forbidden(),
             "PRIVACY_BUILD must forbid vendor auto-update"
@@ -3391,53 +3370,29 @@ mod tests {
             !msg.contains("curl -fsSL https://x.ai/cli"),
             "must not recommend vendor installers: {msg}"
         );
-        privacy_gate_restore(allow);
     }
 
+    /// Product builds (this default unit-test profile) must not compile in an
+    /// env-based escape hatch. Setting GORK_TEST_ALLOW_UPDATE=1 is a no-op
+    /// unless the crate is built with `--features updater-integration-tests`.
     #[test]
     #[serial_test::serial]
-    fn test_escape_hatch_requires_exact_one_and_debug_assertions() {
-        let (allow,) = privacy_gate_guard();
-        // Empty / arbitrary values must NOT open the gate.
+    fn env_cannot_disable_privacy_gate_without_feature() {
         // SAFETY: serial
         unsafe {
-            std::env::set_var(TEST_ALLOW_UPDATE_ENV, "");
+            std::env::set_var("GORK_TEST_ALLOW_UPDATE", "1");
         }
         assert!(
             vendor_auto_update_forbidden(),
-            "empty env must not disable privacy gate"
+            "without feature updater-integration-tests, env must not open the gate"
         );
         unsafe {
-            std::env::set_var(TEST_ALLOW_UPDATE_ENV, "yes");
+            std::env::remove_var("GORK_TEST_ALLOW_UPDATE");
         }
-        assert!(
-            vendor_auto_update_forbidden(),
-            "non-1 env must not disable privacy gate"
-        );
-        unsafe {
-            std::env::set_var(TEST_ALLOW_UPDATE_ENV, "1");
-        }
-        // cargo test is a debug_assertions build: exact "1" relaxes the gate
-        // so integration suites can exercise install mechanics.
-        #[cfg(debug_assertions)]
-        assert!(
-            !vendor_auto_update_forbidden(),
-            "debug + GORK_TEST_ALLOW_UPDATE=1 should relax gate for installer tests"
-        );
-        // Document release semantics: without debug_assertions the env is ignored.
-        // (This branch is not taken under `cargo test`, but keeps the contract explicit.)
-        #[cfg(not(debug_assertions))]
-        assert!(
-            vendor_auto_update_forbidden(),
-            "release builds must ignore GORK_TEST_ALLOW_UPDATE"
-        );
-        privacy_gate_restore(allow);
     }
 
     #[tokio::test]
-    #[serial_test::serial]
     async fn run_install_script_fail_closed_under_privacy() {
-        let (allow,) = privacy_gate_guard();
         assert!(vendor_auto_update_forbidden());
 
         let cfg = dummy_update_config();
@@ -3455,13 +3410,10 @@ mod tests {
                 "installer={installer}: must not recommend vendor curl: {s}"
             );
         }
-        privacy_gate_restore(allow);
     }
 
     #[tokio::test]
-    #[serial_test::serial]
     async fn ensure_latest_on_disk_no_install_under_privacy() {
-        let (allow,) = privacy_gate_guard();
         assert!(vendor_auto_update_forbidden());
 
         let cfg = dummy_update_config();
@@ -3477,13 +3429,10 @@ mod tests {
             !outcome.relaunch_needed,
             "must not claim relaunch after a privacy no-op"
         );
-        privacy_gate_restore(allow);
     }
 
     #[tokio::test]
-    #[serial_test::serial]
     async fn auto_update_target_none_under_privacy() {
-        let (allow,) = privacy_gate_guard();
         assert!(vendor_auto_update_forbidden());
         let cfg = dummy_update_config();
         assert_eq!(
@@ -3491,13 +3440,10 @@ mod tests {
             None,
             "auto_update_target must not return a vendor install plan"
         );
-        privacy_gate_restore(allow);
     }
 
     #[tokio::test]
-    #[serial_test::serial]
     async fn check_update_status_does_not_advertise_vendor_update_under_privacy() {
-        let (allow,) = privacy_gate_guard();
         assert!(vendor_auto_update_forbidden());
         let cfg = dummy_update_config();
         let status = check_update_status(&cfg).await;
@@ -3512,13 +3458,10 @@ mod tests {
             err.contains("never installs from vendor") || err.contains("x.ai"),
             "unexpected status error: {err}"
         );
-        privacy_gate_restore(allow);
     }
 
     #[tokio::test]
-    #[serial_test::serial]
     async fn run_update_fail_closed_under_privacy() {
-        let (allow,) = privacy_gate_guard();
         assert!(vendor_auto_update_forbidden());
         let mut cfg = dummy_update_config();
         let err = run_update(false, None, None, &mut cfg)
@@ -3529,26 +3472,20 @@ mod tests {
             s.contains("never installs from vendor") || s.contains("x.ai"),
             "unexpected error: {s}"
         );
-        privacy_gate_restore(allow);
     }
 
     #[tokio::test]
-    #[serial_test::serial]
     async fn run_update_if_available_is_noop_under_privacy() {
-        let (allow,) = privacy_gate_guard();
         assert!(vendor_auto_update_forbidden());
         let cfg = dummy_update_config();
         let ran = run_update_if_available(UpdateRunMode::Blocking, false, &cfg)
             .await
             .expect("must return Ok(false), not panic");
         assert!(!ran, "must not run a blocking vendor update");
-        privacy_gate_restore(allow);
     }
 
     #[tokio::test]
-    #[serial_test::serial]
     async fn check_update_background_is_noop_under_privacy() {
-        let (allow,) = privacy_gate_guard();
         assert!(vendor_auto_update_forbidden());
         let cfg = dummy_update_config();
         let bg = check_update_background(&cfg).await;
@@ -3560,7 +3497,6 @@ mod tests {
             bg.download.is_none(),
             "background check must not spawn a download child"
         );
-        privacy_gate_restore(allow);
     }
 
     // ──────────────────────────────────────────────────────────────────────

--- a/crates/codegen/xai-grok-update/src/auto_update.rs
+++ b/crates/codegen/xai-grok-update/src/auto_update.rs
@@ -44,11 +44,42 @@ fn reinstall_hint(installer: &str) -> String {
     }
 }
 
+/// Env var that integration tests set to exercise installer mechanics against
+/// local mocks. Must never be set in production user environments.
+const TEST_ALLOW_UPDATE_ENV: &str = "GORK_TEST_ALLOW_UPDATE";
+
 /// Gork Build never auto-updates from vendor (x.ai) channels. Enabling that
 /// path would download official Grok Build and overwrite the community binary.
+///
+/// This is the single policy flag for every install/update entry point.
+/// Callers must check it, and [`run_install_script`] enforces it as the
+/// last line of defense.
+///
+/// When [`TEST_ALLOW_UPDATE_ENV`] is set, the gate is relaxed so crate
+/// integration tests can drive installer code against local fake servers.
+/// Production binaries never set that variable.
 #[inline]
-fn vendor_auto_update_forbidden() -> bool {
+pub fn vendor_auto_update_forbidden() -> bool {
+    if std::env::var_os(TEST_ALLOW_UPDATE_ENV).is_some() {
+        return false;
+    }
     xai_grok_version::PRIVACY_BUILD || xai_grok_version::research_data_collection_forbidden()
+}
+
+/// User-facing explanation when an install/update path is blocked.
+pub fn vendor_update_blocked_message() -> String {
+    format!(
+        "Gork Build never installs from vendor (x.ai) update channels — that would \
+         replace this privacy fork with official Grok Build.\n\n\
+         Rebuild from source instead:\n  {}\n\n\
+         Community releases (when published): https://github.com/thedavidweng/gork-build/releases",
+        manual_install_cmd()
+    )
+}
+
+/// Err used by install/update chokepoints under [`vendor_auto_update_forbidden`].
+fn vendor_update_blocked_err() -> anyhow::Error {
+    anyhow::anyhow!("{}", vendor_update_blocked_message())
 }
 
 #[derive(Debug, serde::Serialize)]
@@ -112,6 +143,19 @@ pub async fn check_update_status(update_config: &UpdateConfig) -> UpdateStatus {
     let current_config = config::load_config().await;
     let auto_update = current_config.cli.auto_update;
     let channel = update_config.channel.clone();
+
+    // Privacy build: do not probe vendor update endpoints at all.
+    if vendor_auto_update_forbidden() {
+        return UpdateStatus {
+            current_version,
+            latest_version: None,
+            update_available: false,
+            installer,
+            channel,
+            auto_update: Some(false),
+            error: Some(vendor_update_blocked_message()),
+        };
+    }
 
     let Some(ref inst) = installer else {
         return UpdateStatus {
@@ -180,6 +224,9 @@ pub async fn check_update_status(update_config: &UpdateConfig) -> UpdateStatus {
 /// on the installer (via `installer_allows_downgrade`) so npm is never
 /// downgraded — the decision depends on the installer, never the caller.
 pub async fn auto_update_target(update_config: &UpdateConfig) -> Option<(&'static str, String)> {
+    if vendor_auto_update_forbidden() {
+        return None;
+    }
     let installer = get_installer().await?;
     let current = get_installed_grok_version();
     let latest = fetch_latest_version(installer, update_config).await.ok()?;
@@ -226,6 +273,11 @@ pub async fn ensure_latest_on_disk(update_config: &UpdateConfig) -> Result<Ensur
         installed: None,
         relaunch_needed: false,
     };
+    // Leader hourly path previously bypassed privacy gates and could install
+    // official Grok Build via run_install_script → install_internal (x.ai/cli).
+    if vendor_auto_update_forbidden() {
+        return Ok(outcome);
+    }
     let Some(installer) = get_installer().await else {
         return Ok(outcome);
     };
@@ -692,6 +744,11 @@ pub async fn run_install_script(
     target: Option<&str>,
     update_config: &UpdateConfig,
 ) -> Result<()> {
+    // Last-line chokepoint: every install path (TUI, leader, minimum_version,
+    // `gork update`, npm / gh-release / internal) must pass here.
+    if vendor_auto_update_forbidden() {
+        return Err(vendor_update_blocked_err());
+    }
     let result = match installer {
         "npm" => install_npm(
             target,
@@ -1092,6 +1149,12 @@ async fn download_cli_artifact_from_gcs(
 }
 
 async fn install_internal(target: Option<&str>, update_config: &UpdateConfig) -> Result<()> {
+    // Belt-and-suspenders: production internal installer always hits x.ai/cli
+    // (or its GCS fallback). Never run under a privacy build even if a caller
+    // forgets to go through run_install_script.
+    if vendor_auto_update_forbidden() {
+        return Err(vendor_update_blocked_err());
+    }
     install_internal_from_bases(target, update_config, crate::version::CLI_BASE_URLS).await
 }
 
@@ -2166,6 +2229,11 @@ pub async fn run_update(
     channel_switch: Option<&str>,
     update_config: &mut UpdateConfig,
 ) -> Result<Option<String>> {
+    // Manual `gork update` must not pull vendor binaries either.
+    if vendor_auto_update_forbidden() {
+        eprintln!("{}", vendor_update_blocked_message());
+        return Err(vendor_update_blocked_err());
+    }
     apply_channel_switch(channel_switch, update_config).await;
     let installer = match get_installer().await {
         Some(i) => i,
@@ -3261,6 +3329,188 @@ mod tests {
     fn test_reinstall_hint_empty_falls_back_to_internal() {
         let hint = reinstall_hint("");
         assert_eq!(hint, reinstall_hint("internal"));
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    // Privacy / vendor-update hard-off (Gork Build)
+    // ──────────────────────────────────────────────────────────────────────
+
+    fn privacy_gate_guard() -> (Option<std::ffi::OsString>,) {
+        let allow = std::env::var_os(TEST_ALLOW_UPDATE_ENV);
+        // SAFETY: unit tests that touch this env are #[serial].
+        unsafe {
+            std::env::remove_var(TEST_ALLOW_UPDATE_ENV);
+        }
+        (allow,)
+    }
+
+    fn privacy_gate_restore(allow: Option<std::ffi::OsString>) {
+        unsafe {
+            match allow {
+                Some(v) => std::env::set_var(TEST_ALLOW_UPDATE_ENV, v),
+                None => std::env::remove_var(TEST_ALLOW_UPDATE_ENV),
+            }
+        }
+    }
+
+    fn dummy_update_config() -> UpdateConfig {
+        UpdateConfig {
+            proxy_base_url: "https://example.invalid/v1".into(),
+            auth_scope: "test".into(),
+            deployment_key: None,
+            alpha_test_key: None,
+            channel: "stable".into(),
+            npm_registry: None,
+        }
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn privacy_build_forbids_vendor_auto_update() {
+        let (allow,) = privacy_gate_guard();
+        assert!(
+            vendor_auto_update_forbidden(),
+            "PRIVACY_BUILD must forbid vendor auto-update"
+        );
+        let msg = vendor_update_blocked_message();
+        assert!(
+            msg.contains("cargo build") || msg.contains("source"),
+            "blocked message should point at source rebuild: {msg}"
+        );
+        assert!(
+            !msg.contains("curl -fsSL https://x.ai/cli"),
+            "must not recommend vendor installers: {msg}"
+        );
+        privacy_gate_restore(allow);
+    }
+
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn run_install_script_fail_closed_under_privacy() {
+        let (allow,) = privacy_gate_guard();
+        assert!(vendor_auto_update_forbidden());
+
+        let cfg = dummy_update_config();
+        for installer in ["internal", "npm", "gh-release", "unknown"] {
+            let err = run_install_script(installer, Some("9.9.9"), &cfg)
+                .await
+                .expect_err("run_install_script must refuse under privacy");
+            let s = format!("{err:#}");
+            assert!(
+                s.contains("never installs from vendor") || s.contains("x.ai"),
+                "installer={installer}: unexpected error: {s}"
+            );
+            assert!(
+                !s.contains("curl -fsSL https://x.ai/cli"),
+                "installer={installer}: must not recommend vendor curl: {s}"
+            );
+        }
+        privacy_gate_restore(allow);
+    }
+
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn ensure_latest_on_disk_no_install_under_privacy() {
+        let (allow,) = privacy_gate_guard();
+        assert!(vendor_auto_update_forbidden());
+
+        let cfg = dummy_update_config();
+        // Must not contact network or install — returns empty outcome.
+        let outcome = ensure_latest_on_disk(&cfg)
+            .await
+            .expect("privacy path is Ok(no-op), not network error");
+        assert_eq!(
+            outcome.installed, None,
+            "leader hourly path must not install under privacy"
+        );
+        assert!(
+            !outcome.relaunch_needed,
+            "must not claim relaunch after a privacy no-op"
+        );
+        privacy_gate_restore(allow);
+    }
+
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn auto_update_target_none_under_privacy() {
+        let (allow,) = privacy_gate_guard();
+        assert!(vendor_auto_update_forbidden());
+        let cfg = dummy_update_config();
+        assert_eq!(
+            auto_update_target(&cfg).await,
+            None,
+            "auto_update_target must not return a vendor install plan"
+        );
+        privacy_gate_restore(allow);
+    }
+
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn check_update_status_does_not_advertise_vendor_update_under_privacy() {
+        let (allow,) = privacy_gate_guard();
+        assert!(vendor_auto_update_forbidden());
+        let cfg = dummy_update_config();
+        let status = check_update_status(&cfg).await;
+        assert!(
+            !status.update_available,
+            "must not advertise a vendor update"
+        );
+        assert_eq!(status.latest_version, None);
+        assert_eq!(status.auto_update, Some(false));
+        let err = status.error.expect("must explain why update is blocked");
+        assert!(
+            err.contains("never installs from vendor") || err.contains("x.ai"),
+            "unexpected status error: {err}"
+        );
+        privacy_gate_restore(allow);
+    }
+
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn run_update_fail_closed_under_privacy() {
+        let (allow,) = privacy_gate_guard();
+        assert!(vendor_auto_update_forbidden());
+        let mut cfg = dummy_update_config();
+        let err = run_update(false, None, None, &mut cfg)
+            .await
+            .expect_err("manual gork update must refuse vendor install");
+        let s = format!("{err:#}");
+        assert!(
+            s.contains("never installs from vendor") || s.contains("x.ai"),
+            "unexpected error: {s}"
+        );
+        privacy_gate_restore(allow);
+    }
+
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn run_update_if_available_is_noop_under_privacy() {
+        let (allow,) = privacy_gate_guard();
+        assert!(vendor_auto_update_forbidden());
+        let cfg = dummy_update_config();
+        let ran = run_update_if_available(UpdateRunMode::Blocking, false, &cfg)
+            .await
+            .expect("must return Ok(false), not panic");
+        assert!(!ran, "must not run a blocking vendor update");
+        privacy_gate_restore(allow);
+    }
+
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn check_update_background_is_noop_under_privacy() {
+        let (allow,) = privacy_gate_guard();
+        assert!(vendor_auto_update_forbidden());
+        let cfg = dummy_update_config();
+        let bg = check_update_background(&cfg).await;
+        assert!(
+            bg.update.is_none(),
+            "background check must not surface a vendor update"
+        );
+        assert!(
+            bg.download.is_none(),
+            "background check must not spawn a download child"
+        );
+        privacy_gate_restore(allow);
     }
 
     // ──────────────────────────────────────────────────────────────────────

--- a/crates/codegen/xai-grok-update/src/auto_update.rs
+++ b/crates/codegen/xai-grok-update/src/auto_update.rs
@@ -44,8 +44,12 @@ fn reinstall_hint(installer: &str) -> String {
     }
 }
 
-/// Env var that integration tests set to exercise installer mechanics against
-/// local mocks. Must never be set in production user environments.
+/// Env var that **debug-profile integration tests** may set to `"1"` so local
+/// mock installer suites can exercise download/swap mechanics.
+///
+/// **Release product binaries ignore this entirely** (`cfg(debug_assertions)`
+/// only). Even in debug, only the exact value `"1"` relaxes the gate — empty
+/// or other values do not.
 const TEST_ALLOW_UPDATE_ENV: &str = "GORK_TEST_ALLOW_UPDATE";
 
 /// Gork Build never auto-updates from vendor (x.ai) channels. Enabling that
@@ -55,13 +59,19 @@ const TEST_ALLOW_UPDATE_ENV: &str = "GORK_TEST_ALLOW_UPDATE";
 /// Callers must check it, and [`run_install_script`] enforces it as the
 /// last line of defense.
 ///
-/// When [`TEST_ALLOW_UPDATE_ENV`] is set, the gate is relaxed so crate
-/// integration tests can drive installer code against local fake servers.
-/// Production binaries never set that variable.
+/// Debug-only test hook: when built with `debug_assertions` and
+/// `GORK_TEST_ALLOW_UPDATE=1`, the gate is relaxed for crate integration
+/// tests against local fake servers. **Release builds never honor the env
+/// var** — privacy hard-off cannot be re-enabled at runtime in product
+/// binaries.
 #[inline]
 pub fn vendor_auto_update_forbidden() -> bool {
-    if std::env::var_os(TEST_ALLOW_UPDATE_ENV).is_some() {
-        return false;
+    // Release product paths: always honor privacy. No env re-enable.
+    #[cfg(debug_assertions)]
+    {
+        if std::env::var(TEST_ALLOW_UPDATE_ENV).as_deref() == Ok("1") {
+            return false;
+        }
     }
     xai_grok_version::PRIVACY_BUILD || xai_grok_version::research_data_collection_forbidden()
 }
@@ -3380,6 +3390,46 @@ mod tests {
         assert!(
             !msg.contains("curl -fsSL https://x.ai/cli"),
             "must not recommend vendor installers: {msg}"
+        );
+        privacy_gate_restore(allow);
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn test_escape_hatch_requires_exact_one_and_debug_assertions() {
+        let (allow,) = privacy_gate_guard();
+        // Empty / arbitrary values must NOT open the gate.
+        // SAFETY: serial
+        unsafe {
+            std::env::set_var(TEST_ALLOW_UPDATE_ENV, "");
+        }
+        assert!(
+            vendor_auto_update_forbidden(),
+            "empty env must not disable privacy gate"
+        );
+        unsafe {
+            std::env::set_var(TEST_ALLOW_UPDATE_ENV, "yes");
+        }
+        assert!(
+            vendor_auto_update_forbidden(),
+            "non-1 env must not disable privacy gate"
+        );
+        unsafe {
+            std::env::set_var(TEST_ALLOW_UPDATE_ENV, "1");
+        }
+        // cargo test is a debug_assertions build: exact "1" relaxes the gate
+        // so integration suites can exercise install mechanics.
+        #[cfg(debug_assertions)]
+        assert!(
+            !vendor_auto_update_forbidden(),
+            "debug + GORK_TEST_ALLOW_UPDATE=1 should relax gate for installer tests"
+        );
+        // Document release semantics: without debug_assertions the env is ignored.
+        // (This branch is not taken under `cargo test`, but keeps the contract explicit.)
+        #[cfg(not(debug_assertions))]
+        assert!(
+            vendor_auto_update_forbidden(),
+            "release builds must ignore GORK_TEST_ALLOW_UPDATE"
         );
         privacy_gate_restore(allow);
     }

--- a/crates/codegen/xai-grok-update/src/auto_update.rs
+++ b/crates/codegen/xai-grok-update/src/auto_update.rs
@@ -3355,8 +3355,19 @@ mod tests {
         }
     }
 
+    /// Ensure product-policy assertions are not poisoned by a leftover
+    /// installer-mock env var (only meaningful when the feature is on).
+    fn clear_installer_test_escape_env() {
+        // SAFETY: only called from #[serial] privacy unit tests.
+        unsafe {
+            std::env::remove_var("GORK_TEST_ALLOW_UPDATE");
+        }
+    }
+
     #[test]
+    #[serial_test::serial]
     fn privacy_build_forbids_vendor_auto_update() {
+        clear_installer_test_escape_env();
         assert!(
             vendor_auto_update_forbidden(),
             "PRIVACY_BUILD must forbid vendor auto-update"
@@ -3375,6 +3386,10 @@ mod tests {
     /// Product builds (this default unit-test profile) must not compile in an
     /// env-based escape hatch. Setting GORK_TEST_ALLOW_UPDATE=1 is a no-op
     /// unless the crate is built with `--features updater-integration-tests`.
+    ///
+    /// Only compiled when the feature is *off* — with the feature on, env
+    /// intentionally opens the gate (covered by integration tests).
+    #[cfg(not(feature = "updater-integration-tests"))]
     #[test]
     #[serial_test::serial]
     fn env_cannot_disable_privacy_gate_without_feature() {
@@ -3391,8 +3406,35 @@ mod tests {
         }
     }
 
+    /// With the installer-test feature, env=1 must open the gate (and only then).
+    #[cfg(feature = "updater-integration-tests")]
+    #[test]
+    #[serial_test::serial]
+    fn env_opens_privacy_gate_only_with_feature() {
+        // SAFETY: serial
+        unsafe {
+            std::env::remove_var("GORK_TEST_ALLOW_UPDATE");
+        }
+        assert!(
+            vendor_auto_update_forbidden(),
+            "even with feature, gate stays on without env=1"
+        );
+        unsafe {
+            std::env::set_var("GORK_TEST_ALLOW_UPDATE", "1");
+        }
+        assert!(
+            !vendor_auto_update_forbidden(),
+            "feature + GORK_TEST_ALLOW_UPDATE=1 must open the gate for installer mocks"
+        );
+        unsafe {
+            std::env::remove_var("GORK_TEST_ALLOW_UPDATE");
+        }
+    }
+
     #[tokio::test]
+    #[serial_test::serial]
     async fn run_install_script_fail_closed_under_privacy() {
+        clear_installer_test_escape_env();
         assert!(vendor_auto_update_forbidden());
 
         let cfg = dummy_update_config();
@@ -3413,7 +3455,9 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial_test::serial]
     async fn ensure_latest_on_disk_no_install_under_privacy() {
+        clear_installer_test_escape_env();
         assert!(vendor_auto_update_forbidden());
 
         let cfg = dummy_update_config();
@@ -3432,7 +3476,9 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial_test::serial]
     async fn auto_update_target_none_under_privacy() {
+        clear_installer_test_escape_env();
         assert!(vendor_auto_update_forbidden());
         let cfg = dummy_update_config();
         assert_eq!(
@@ -3443,7 +3489,9 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial_test::serial]
     async fn check_update_status_does_not_advertise_vendor_update_under_privacy() {
+        clear_installer_test_escape_env();
         assert!(vendor_auto_update_forbidden());
         let cfg = dummy_update_config();
         let status = check_update_status(&cfg).await;
@@ -3461,7 +3509,9 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial_test::serial]
     async fn run_update_fail_closed_under_privacy() {
+        clear_installer_test_escape_env();
         assert!(vendor_auto_update_forbidden());
         let mut cfg = dummy_update_config();
         let err = run_update(false, None, None, &mut cfg)
@@ -3475,7 +3525,9 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial_test::serial]
     async fn run_update_if_available_is_noop_under_privacy() {
+        clear_installer_test_escape_env();
         assert!(vendor_auto_update_forbidden());
         let cfg = dummy_update_config();
         let ran = run_update_if_available(UpdateRunMode::Blocking, false, &cfg)
@@ -3485,7 +3537,9 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial_test::serial]
     async fn check_update_background_is_noop_under_privacy() {
+        clear_installer_test_escape_env();
         assert!(vendor_auto_update_forbidden());
         let cfg = dummy_update_config();
         let bg = check_update_background(&cfg).await;

--- a/crates/codegen/xai-grok-update/src/auto_update.rs
+++ b/crates/codegen/xai-grok-update/src/auto_update.rs
@@ -109,6 +109,7 @@ pub fn print_update_status(status: &UpdateStatus, json: bool) -> anyhow::Result<
         return Ok(());
     }
 
+    // Probe / network failures only — not privacy policy hard-off.
     if let Some(error) = status.error.as_deref() {
         println!(
             "Gork Build - v{} [{}]",
@@ -119,6 +120,21 @@ pub fn print_update_status(status: &UpdateStatus, json: bool) -> anyhow::Result<
     }
 
     let channel_label = format!(" [{}]", status.channel);
+
+    // Expected policy state for Gork Build: no vendor update path, not a failure.
+    if vendor_auto_update_forbidden()
+        && !status.update_available
+        && status.latest_version.is_none()
+        && status.auto_update == Some(false)
+    {
+        println!(
+            "Gork Build - v{}{}",
+            status.current_version, channel_label
+        );
+        println!("Auto-update: disabled (privacy build never installs from vendor channels).");
+        println!("{}", vendor_update_blocked_message());
+        return Ok(());
+    }
 
     if status.update_available {
         if let Some(latest_version) = status.latest_version.as_deref() {
@@ -152,6 +168,9 @@ pub async fn check_update_status(update_config: &UpdateConfig) -> UpdateStatus {
     let channel = update_config.channel.clone();
 
     // Privacy build: do not probe vendor update endpoints at all.
+    // Leave `error` as None — this is expected policy, not a failed check.
+    // `auto_update: Some(false)` + no latest is the machine-readable signal;
+    // human text comes from print_update_status.
     if vendor_auto_update_forbidden() {
         return UpdateStatus {
             current_version,
@@ -160,7 +179,7 @@ pub async fn check_update_status(update_config: &UpdateConfig) -> UpdateStatus {
             installer,
             channel,
             auto_update: Some(false),
-            error: Some(vendor_update_blocked_message()),
+            error: None,
         };
     }
 
@@ -3501,11 +3520,31 @@ mod tests {
         );
         assert_eq!(status.latest_version, None);
         assert_eq!(status.auto_update, Some(false));
-        let err = status.error.expect("must explain why update is blocked");
-        assert!(
-            err.contains("never installs from vendor") || err.contains("x.ai"),
-            "unexpected status error: {err}"
+        // Policy hard-off is not a probe failure — leave error empty so
+        // print_update_status does not render "Update check failed: ...".
+        assert_eq!(
+            status.error, None,
+            "privacy hard-off must not use the error slot (healthy build)"
         );
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn print_update_status_privacy_is_informational_not_failure() {
+        clear_installer_test_escape_env();
+        assert!(vendor_auto_update_forbidden());
+        let status = UpdateStatus {
+            current_version: "0.1.0".into(),
+            latest_version: None,
+            update_available: false,
+            installer: None,
+            channel: "stable".into(),
+            auto_update: Some(false),
+            error: None,
+        };
+        // Must succeed without panicking; human output is informational.
+        print_update_status(&status, false).expect("print must succeed");
+        print_update_status(&status, true).expect("json print must succeed");
     }
 
     #[tokio::test]

--- a/crates/codegen/xai-grok-update/src/auto_update.rs
+++ b/crates/codegen/xai-grok-update/src/auto_update.rs
@@ -127,10 +127,7 @@ pub fn print_update_status(status: &UpdateStatus, json: bool) -> anyhow::Result<
         && status.latest_version.is_none()
         && status.auto_update == Some(false)
     {
-        println!(
-            "Gork Build - v{}{}",
-            status.current_version, channel_label
-        );
+        println!("Gork Build - v{}{}", status.current_version, channel_label);
         println!("Auto-update: disabled (privacy build never installs from vendor channels).");
         println!("{}", vendor_update_blocked_message());
         return Ok(());

--- a/crates/codegen/xai-grok-update/src/minimum_version.rs
+++ b/crates/codegen/xai-grok-update/src/minimum_version.rs
@@ -38,7 +38,7 @@ pub(crate) enum EnforcementOutcome {
 pub(crate) enum MinimumVersionError {
     /// `source` chains via `Error::source()`; omitted from `Display`.
     #[error(
-        "The minimum version \"{value}\" in your Grok configuration \
+        "The minimum version \"{value}\" in your Gork Build configuration \
          isn't a valid version number. Update `cli.minimum_version` and try again."
     )]
     InvalidMinimum {
@@ -47,22 +47,24 @@ pub(crate) enum MinimumVersionError {
         source: semver::Error,
     },
     #[error(
-        "This version of Grok ({current}) is no longer supported. \
-         Run `gork update` to install version {minimum} or later."
+        "This version of Gork Build ({current}) is no longer supported. \
+         Rebuild from source for version {minimum} or later \
+         (vendor auto-update is disabled in this fork)."
     )]
     AutoUpdateDisabled { current: String, minimum: String },
     /// `npm` / `gh` / `internal` GCS — none detected.
     #[error(
-        "This version of Grok ({current}) is no longer supported. \
-         Run `gork update` to install version {minimum} or later."
+        "This version of Gork Build ({current}) is no longer supported. \
+         Rebuild from source for version {minimum} or later \
+         (vendor auto-update is disabled in this fork)."
     )]
     NoInstaller { current: String, minimum: String },
     /// `detail` is telemetry-only; omitted from `Display` to avoid stacking
     /// the installer's own action language.
     #[error(
-        "This version of Grok ({current}) is no longer supported, \
-         and the update to version {minimum} didn't complete.\n\n\
-         Run `gork update` to try again."
+        "This version of Gork Build ({current}) is no longer supported, \
+         and an update to version {minimum} didn't complete.\n\n\
+         Rebuild from source (vendor auto-update is disabled in this fork)."
     )]
     UpgradeFailed {
         current: String,
@@ -72,7 +74,7 @@ pub(crate) enum MinimumVersionError {
     /// Latest release is known but still below the floor (vs `NoReleaseFound`,
     /// which couldn't probe at all).
     #[error(
-        "This version of Grok ({current}) is no longer supported. \
+        "This version of Gork Build ({current}) is no longer supported. \
          Version {minimum} or later is required, but the most recent release is {latest}. \
          Contact your administrator."
     )]
@@ -83,15 +85,15 @@ pub(crate) enum MinimumVersionError {
     },
     /// Couldn't probe the registry — likely transient.
     #[error(
-        "This version of Grok ({current}) is no longer supported. \
+        "This version of Gork Build ({current}) is no longer supported. \
          Version {minimum} or later is required, but no release was found. \
          Check your network connection, or contact your administrator."
     )]
     NoReleaseFound { current: String, minimum: String },
     /// `gork update --version X` requested a version below the floor.
     #[error(
-        "Cannot install Grok {target}: the configured minimum is {minimum}. \
-         Run `gork update` to install the latest allowed version."
+        "Cannot install Gork Build {target}: the configured minimum is {minimum}. \
+         Rebuild from source for the latest allowed version."
     )]
     TargetBelowFloor { target: String, minimum: String },
     /// Privacy build: never auto-install from vendor channels to satisfy a floor.
@@ -246,7 +248,7 @@ pub(crate) async fn enforce_minimum_version(
 
     info!(%current, %target, installer, "minimum_version: installing upgrade");
     eprintln!(
-        "This version of Gork ({current}) is no longer supported. \
+        "This version of Gork Build ({current}) is no longer supported. \
          Updating to {target}…"
     );
 
@@ -412,18 +414,18 @@ mod tests {
     #[tokio::test]
     #[serial_test::serial]
     async fn privacy_build_refuses_minimum_version_vendor_install() {
-        // Ensure the product privacy gate is active (not the installer-test escape hatch).
-        let allow_saved = std::env::var("GORK_TEST_ALLOW_UPDATE").ok();
         let ver_saved = std::env::var("GROK_TEST_VERSION").ok();
         // SAFETY: #[serial]
         unsafe {
-            std::env::remove_var("GORK_TEST_ALLOW_UPDATE");
+            // Even with GORK_TEST_ALLOW_UPDATE=1, product unit tests are not
+            // built with `updater-integration-tests`, so the gate stays on.
+            std::env::set_var("GORK_TEST_ALLOW_UPDATE", "1");
             std::env::set_var("GROK_TEST_VERSION", "0.1.50");
         }
 
         assert!(
             crate::auto_update::vendor_auto_update_forbidden(),
-            "privacy gate must be active for this test"
+            "privacy gate must stay on without updater-integration-tests feature"
         );
 
         let cfg = UpdateConfig {
@@ -462,10 +464,7 @@ mod tests {
 
         // SAFETY: restore
         unsafe {
-            match allow_saved {
-                Some(v) => std::env::set_var("GORK_TEST_ALLOW_UPDATE", v),
-                None => std::env::remove_var("GORK_TEST_ALLOW_UPDATE"),
-            }
+            std::env::remove_var("GORK_TEST_ALLOW_UPDATE");
             match ver_saved {
                 Some(v) => std::env::set_var("GROK_TEST_VERSION", v),
                 None => std::env::remove_var("GROK_TEST_VERSION"),

--- a/crates/codegen/xai-grok-update/src/minimum_version.rs
+++ b/crates/codegen/xai-grok-update/src/minimum_version.rs
@@ -7,7 +7,9 @@
 //! Set `GROK_TEST_VERSION` to manually exercise either path without producing
 //! a real out-of-date build.
 
-use crate::auto_update::{get_installer, run_install_script};
+use crate::auto_update::{
+    get_installer, run_install_script, vendor_auto_update_forbidden, vendor_update_blocked_message,
+};
 use crate::version::{
     UpdateConfig, fetch_latest_version, get_installed_grok_version, write_version_cache,
 };
@@ -23,7 +25,7 @@ enum MinimumVersionDecision {
 
 /// Outcome of a successful enforcement pass.
 #[derive(Debug, Clone, PartialEq, Eq)]
-enum EnforcementOutcome {
+pub(crate) enum EnforcementOutcome {
     Allowed,
     /// New binary on disk; caller MUST restart — running process is still old.
     Upgraded,
@@ -92,6 +94,13 @@ pub(crate) enum MinimumVersionError {
          Run `gork update` to install the latest allowed version."
     )]
     TargetBelowFloor { target: String, minimum: String },
+    /// Privacy build: never auto-install from vendor channels to satisfy a floor.
+    #[error("{message}")]
+    VendorUpdateForbidden {
+        current: String,
+        minimum: String,
+        message: String,
+    },
 }
 
 /// Pure check against the configured floor. Empty / whitespace-only
@@ -189,7 +198,9 @@ fn pick_target_version(latest: Option<&str>, minimum: &str) -> String {
 
 /// Call once at startup, before any user-facing UI. On `Ok(Upgraded)` the
 /// caller MUST restart. On `Err`, print and exit non-zero.
-async fn enforce_minimum_version(
+///
+/// `pub(crate)` so unit tests can drive the shipped enforcement path.
+pub(crate) async fn enforce_minimum_version(
     minimum_version: Option<&str>,
     update_config: &UpdateConfig,
 ) -> Result<EnforcementOutcome, MinimumVersionError> {
@@ -201,6 +212,22 @@ async fn enforce_minimum_version(
     };
 
     info!(%current, %minimum, "minimum_version: below floor; attempting auto-update");
+
+    // Privacy / Gork Build: never satisfy a remote or local floor by pulling
+    // vendor (x.ai) installers — that would replace this fork with official
+    // Grok Build. Fail closed with rebuild guidance instead.
+    if vendor_auto_update_forbidden() {
+        warn!(%current, %minimum, "minimum_version: vendor auto-update forbidden (privacy build)");
+        let message = format!(
+            "This version of Gork Build ({current}) is below the configured floor ({minimum}).\n\n{}",
+            vendor_update_blocked_message()
+        );
+        return Err(MinimumVersionError::VendorUpdateForbidden {
+            current,
+            minimum,
+            message,
+        });
+    }
 
     // `None` is "default on"; only explicit `false` opts out.
     let cfg = config::load_config().await;
@@ -219,7 +246,7 @@ async fn enforce_minimum_version(
 
     info!(%current, %target, installer, "minimum_version: installing upgrade");
     eprintln!(
-        "This version of Grok ({current}) is no longer supported. \
+        "This version of Gork ({current}) is no longer supported. \
          Updating to {target}…"
     );
 
@@ -379,6 +406,70 @@ mod tests {
         match saved {
             Some(v) => unsafe { std::env::set_var("GROK_TEST_VERSION", v) },
             None => unsafe { std::env::remove_var("GROK_TEST_VERSION") },
+        }
+    }
+
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn privacy_build_refuses_minimum_version_vendor_install() {
+        // Ensure the product privacy gate is active (not the installer-test escape hatch).
+        let allow_saved = std::env::var("GORK_TEST_ALLOW_UPDATE").ok();
+        let ver_saved = std::env::var("GROK_TEST_VERSION").ok();
+        // SAFETY: #[serial]
+        unsafe {
+            std::env::remove_var("GORK_TEST_ALLOW_UPDATE");
+            std::env::set_var("GROK_TEST_VERSION", "0.1.50");
+        }
+
+        assert!(
+            crate::auto_update::vendor_auto_update_forbidden(),
+            "privacy gate must be active for this test"
+        );
+
+        let cfg = UpdateConfig {
+            proxy_base_url: "https://example.invalid/v1".into(),
+            auth_scope: "test".into(),
+            deployment_key: None,
+            alpha_test_key: None,
+            channel: "stable".into(),
+            npm_registry: None,
+        };
+
+        let err = enforce_minimum_version(Some("9.9.9"), &cfg)
+            .await
+            .expect_err("must fail closed without vendor install");
+        match err {
+            MinimumVersionError::VendorUpdateForbidden {
+                current,
+                minimum,
+                message,
+            } => {
+                assert_eq!(current, "0.1.50");
+                assert_eq!(minimum, "9.9.9");
+                assert!(
+                    message.contains("never installs from vendor")
+                        || message.contains("x.ai")
+                        || message.contains("cargo build"),
+                    "message must guide rebuild, got: {message}"
+                );
+                assert!(
+                    !message.contains("curl -fsSL https://x.ai/cli"),
+                    "must not recommend vendor curl installer: {message}"
+                );
+            }
+            other => panic!("expected VendorUpdateForbidden, got {other:?}"),
+        }
+
+        // SAFETY: restore
+        unsafe {
+            match allow_saved {
+                Some(v) => std::env::set_var("GORK_TEST_ALLOW_UPDATE", v),
+                None => std::env::remove_var("GORK_TEST_ALLOW_UPDATE"),
+            }
+            match ver_saved {
+                Some(v) => std::env::set_var("GROK_TEST_VERSION", v),
+                None => std::env::remove_var("GROK_TEST_VERSION"),
+            }
         }
     }
 }

--- a/crates/codegen/xai-grok-update/src/minimum_version.rs
+++ b/crates/codegen/xai-grok-update/src/minimum_version.rs
@@ -411,6 +411,9 @@ mod tests {
         }
     }
 
+    /// Asserts that without the installer-test feature, env cannot open the
+    /// gate and minimum-version enforcement stays fail-closed.
+    #[cfg(not(feature = "updater-integration-tests"))]
     #[tokio::test]
     #[serial_test::serial]
     async fn privacy_build_refuses_minimum_version_vendor_install() {

--- a/crates/codegen/xai-grok-update/tests/common/mod.rs
+++ b/crates/codegen/xai-grok-update/tests/common/mod.rs
@@ -56,8 +56,9 @@ pub fn test_home() -> &'static PathBuf {
             std::env::remove_var("GROK_INSTALLER");
             std::env::remove_var("GROK_MANAGED_BY_NPM");
             std::env::remove_var("GROK_MANAGED_BY_INTERNAL");
-            // Installer-mechanics suites exercise download/swap against local
-            // mocks. Production privacy gate is tested separately without this.
+            // Installer-mechanics suites: only effective when the crate is
+            // built with `--features updater-integration-tests`. Product
+            // builds never compile that escape path.
             std::env::set_var("GORK_TEST_ALLOW_UPDATE", "1");
         }
         path

--- a/crates/codegen/xai-grok-update/tests/common/mod.rs
+++ b/crates/codegen/xai-grok-update/tests/common/mod.rs
@@ -56,6 +56,9 @@ pub fn test_home() -> &'static PathBuf {
             std::env::remove_var("GROK_INSTALLER");
             std::env::remove_var("GROK_MANAGED_BY_NPM");
             std::env::remove_var("GROK_MANAGED_BY_INTERNAL");
+            // Installer-mechanics suites exercise download/swap against local
+            // mocks. Production privacy gate is tested separately without this.
+            std::env::set_var("GORK_TEST_ALLOW_UPDATE", "1");
         }
         path
     })

--- a/crates/codegen/xai-grok-update/tests/common/mod.rs
+++ b/crates/codegen/xai-grok-update/tests/common/mod.rs
@@ -57,8 +57,9 @@ pub fn test_home() -> &'static PathBuf {
             std::env::remove_var("GROK_MANAGED_BY_NPM");
             std::env::remove_var("GROK_MANAGED_BY_INTERNAL");
             // Installer-mechanics suites: only effective when the crate is
-            // built with `--features updater-integration-tests`. Product
-            // builds never compile that escape path.
+            // built with `--features updater-integration-tests` (see
+            // #![cfg(feature = "updater-integration-tests")] on those test
+            // binaries). Product builds never compile that escape path.
             std::env::set_var("GORK_TEST_ALLOW_UPDATE", "1");
         }
         path

--- a/crates/codegen/xai-grok-update/tests/test_blitz_cancel.rs
+++ b/crates/codegen/xai-grok-update/tests/test_blitz_cancel.rs
@@ -1,3 +1,7 @@
+#![cfg(feature = "updater-integration-tests")]
+// Requires: cargo test -p xai-grok-update --features updater-integration-tests
+// + GORK_TEST_ALLOW_UPDATE=1 (set by tests/common).
+
 //! Blitz harness: hammer the download + install lifecycle while injecting a
 //! truncation / corruption / cancel at every point, and after every iteration
 //! assert the single invariant that makes the brick impossible:

--- a/crates/codegen/xai-grok-update/tests/test_check_status_regression.rs
+++ b/crates/codegen/xai-grok-update/tests/test_check_status_regression.rs
@@ -1,3 +1,7 @@
+#![cfg(feature = "updater-integration-tests")]
+// Requires: cargo test -p xai-grok-update --features updater-integration-tests
+// + GORK_TEST_ALLOW_UPDATE=1 (set by tests/common).
+
 //! End-to-end regression tests for `check_update_status` that lock in the
 //! exact JSON shape produced by `grok update --check --json` for the failure
 //! modes that real users have hit in the wild.

--- a/crates/codegen/xai-grok-update/tests/test_concurrent_convergence.rs
+++ b/crates/codegen/xai-grok-update/tests/test_concurrent_convergence.rs
@@ -1,3 +1,7 @@
+#![cfg(feature = "updater-integration-tests")]
+// Requires: cargo test -p xai-grok-update --features updater-integration-tests
+// + GORK_TEST_ALLOW_UPDATE=1 (set by tests/common).
+
 //! End-to-end tests for the lock-free concurrent-updater convergence model
 //! (the "double download" fix): updaters key staleness off the on-disk
 //! install, so a binary another process already installed is never

--- a/crates/codegen/xai-grok-update/tests/test_downgrade_matrix.rs
+++ b/crates/codegen/xai-grok-update/tests/test_downgrade_matrix.rs
@@ -1,3 +1,7 @@
+#![cfg(feature = "updater-integration-tests")]
+// Requires: cargo test -p xai-grok-update --features updater-integration-tests
+// + GORK_TEST_ALLOW_UPDATE=1 (set by tests/common).
+
 //! Invariant matrix tests for the rollback/downgrade feature.
 //!
 //! Covers every combination of:

--- a/crates/codegen/xai-grok-update/tests/test_install_internal.rs
+++ b/crates/codegen/xai-grok-update/tests/test_install_internal.rs
@@ -1,3 +1,7 @@
+#![cfg(feature = "updater-integration-tests")]
+// Requires: cargo test -p xai-grok-update --features updater-integration-tests
+// + GORK_TEST_ALLOW_UPDATE=1 (set by tests/common).
+
 //! End-to-end tests for `install_internal` — the GCS-bucket installer used
 //! when `installer = "internal"` is configured.
 //!

--- a/crates/codegen/xai-grok-update/tests/test_subprocess.rs
+++ b/crates/codegen/xai-grok-update/tests/test_subprocess.rs
@@ -217,7 +217,8 @@ async fn install_npm_calls_npm_with_version_arg() {
     assert_eq!(log.len(), 1, "exactly one npm invocation");
     let args = &log[0];
     assert!(args.contains("i -g"), "args: {args}");
-    assert!(args.contains("@xai-official/grok@0.1.181"), "args: {args}");
+    // Gork Build privacy fork installs the community package name.
+    assert!(args.contains("@gork-build/gork@0.1.181"), "args: {args}");
 }
 
 #[tokio::test]
@@ -228,7 +229,7 @@ async fn install_npm_falls_back_to_dist_tag_on_no_target() {
     install_npm_for_test(None, "stable", None).unwrap();
     let log = g.args_log();
     assert!(
-        log[0].contains("@xai-official/grok@latest"),
+        log[0].contains("@gork-build/gork@latest"),
         "stable channel uses @latest dist-tag: {}",
         log[0]
     );
@@ -242,7 +243,7 @@ async fn install_npm_falls_back_to_alpha_dist_tag_on_alpha_channel() {
     install_npm_for_test(None, "alpha", None).unwrap();
     let log = g.args_log();
     assert!(
-        log[0].contains("@xai-official/grok@alpha"),
+        log[0].contains("@gork-build/gork@alpha"),
         "alpha channel uses @alpha dist-tag: {}",
         log[0]
     );

--- a/crates/codegen/xai-grok-version/src/lib.rs
+++ b/crates/codegen/xai-grok-version/src/lib.rs
@@ -78,6 +78,26 @@ pub fn display_version_with_commit(version_with_commit: &str, channel_label: &st
 mod tests {
     use super::*;
 
+    /// Gork Build privacy policy constants — compile-time hard-offs that
+    /// resolvers and updaters consult. These must stay true for this fork.
+    #[test]
+    fn privacy_build_locks_research_and_retention_policy() {
+        assert!(
+            PRIVACY_BUILD,
+            "Gork Build must ship with PRIVACY_BUILD=true"
+        );
+        assert!(
+            research_data_collection_forbidden(),
+            "research_data_collection_forbidden must follow PRIVACY_BUILD"
+        );
+        assert!(
+            coding_data_retention_locked_opt_out(),
+            "coding data retention must be locked opt-out under PRIVACY_BUILD"
+        );
+        assert_eq!(PRODUCT_CLI, "gork");
+        assert_eq!(PRODUCT_NAME, "Gork Build");
+    }
+
     /// Display formatting invariant matrix — verifies label appending
     /// works correctly across all label states (alpha, stable, empty).
     #[test]


### PR DESCRIPTION
## Summary

Follow-up to privacy P0 work: turn **cargo audit** into a real CI hard gate (no `continue-on-error`, no `|| true`).

- Add `.cargo/audit.toml` with **documented** ignores only for residual monorepo issues that cannot be lockfile-patched cleanly today (`rsa` unfixed; `quick-xml` needs a major bump blocked by direct pins).
- Bump fixable lockfile patches (`crossbeam-epoch`, `quinn-proto`).
- New unignored advisories fail the job.

## Stack
Base: `fix/vendor-update-hard-off` (PR #9). Merge after #9 or retarget `main` once #9 lands.

## Test plan
- [x] `cargo audit` exits 0 with current ignores
- [ ] CI `cargo audit` job green on this branch
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/thedavidweng/gork-build/pull/10" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->