### PR TITLE
ci: privacy egress network capture for release gork

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -237,3 +237,34 @@ jobs:
           path: target/release/gork
           if-no-files-found: error
           retention-days: 14
+
+  # Release-binary network capture: CONNECT proxy logs destinations; fail if
+  # denylisted privacy/vendor hosts appear (no MITM required).
+  privacy-egress:
+    name: Privacy egress capture
+    needs: [build-gork]
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Download gork binary
+        uses: actions/download-artifact@v7
+        with:
+          name: gork-linux-x86_64
+          path: target/release
+
+      - name: Run privacy egress check
+        run: |
+          set -euo pipefail
+          chmod +x target/release/gork scripts/privacy_egress_check.sh
+          GORK_BIN=target/release/gork ./scripts/privacy_egress_check.sh
+
+      - name: Upload egress host log
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: privacy-egress-hosts
+          path: ${{ runner.temp }}/gork-privacy-egress.*/hosts*.txt
+          if-no-files-found: ignore
+          retention-days: 14

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -258,6 +258,8 @@ jobs:
         run: |
           set -euo pipefail
           chmod +x target/release/gork scripts/privacy_egress_check.sh
+          export PRIVACY_EGRESS_WORKDIR="${RUNNER_TEMP}/gork-privacy-egress"
+          mkdir -p "$PRIVACY_EGRESS_WORKDIR"
           GORK_BIN=target/release/gork ./scripts/privacy_egress_check.sh
 
       - name: Upload egress host log
@@ -265,6 +267,6 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: privacy-egress-hosts
-          path: ${{ runner.temp }}/gork-privacy-egress.*/hosts*.txt
+          path: ${{ runner.temp }}/gork-privacy-egress/**
           if-no-files-found: ignore
           retention-days: 14

--- a/scripts/privacy_egress_check.sh
+++ b/scripts/privacy_egress_check.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# Privacy egress check: run release `gork` through a local CONNECT proxy and
+# fail if denylisted destinations appear in the host log.
+#
+# Does not require MITM / TLS interception — only CONNECT hostnames are recorded.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+BIN="${GORK_BIN:-target/release/gork}"
+if [[ ! -x "$BIN" ]]; then
+  echo "Building release gork..."
+  cargo build -p xai-grok-pager-bin --release
+  BIN=target/release/gork
+fi
+
+# Prefer runner temp on GHA; fall back to local TMPDIR.
+BASE_TMP="${RUNNER_TEMP:-${TMPDIR:-/tmp}}"
+WORKDIR="${PRIVACY_EGRESS_WORKDIR:-$(mktemp -d "${BASE_TMP}/gork-privacy-egress.XXXXXX")}"
+mkdir -p "$WORKDIR"
+LOG="$WORKDIR/hosts.txt"
+PROXY_PORT="${PRIVACY_EGRESS_PORT:-18080}"
+LISTEN="127.0.0.1:${PROXY_PORT}"
+# Export for CI artifact upload path discovery.
+echo "PRIVACY_EGRESS_WORKDIR=$WORKDIR" >>"${GITHUB_ENV:-/dev/null}" 2>/dev/null || true
+echo "$WORKDIR" >"$WORKDIR/workdir.path"
+
+# Destinations that must never appear during a privacy-hard-off smoke session.
+# (Model/auth hosts are not exercised here — no login; update/telemetry must stay quiet.)
+DENY_REGEX='(mixpanel\.com|api\.mixpanel\.com|x\.ai|storage\.googleapis\.com|sentry\.io|ingest\.sentry\.io)'
+
+python3 "$ROOT/scripts/privacy_egress_proxy.py" --listen "$LISTEN" --log "$LOG" &
+PROXY_PID=$!
+cleanup() {
+  kill "$PROXY_PID" 2>/dev/null || true
+  wait "$PROXY_PID" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+# Wait for proxy
+for _ in $(seq 1 50); do
+  if (echo >"/dev/tcp/127.0.0.1/${PROXY_PORT}") >/dev/null 2>&1; then
+    break
+  fi
+  # bash /dev/tcp may be missing; fall back to python
+  if python3 -c "import socket; s=socket.create_connection(('127.0.0.1',${PROXY_PORT}),1); s.close()" 2>/dev/null; then
+    break
+  fi
+  sleep 0.1
+done
+
+export HTTP_PROXY="http://${LISTEN}"
+export HTTPS_PROXY="http://${LISTEN}"
+export ALL_PROXY="http://${LISTEN}"
+export http_proxy="$HTTP_PROXY"
+export https_proxy="$HTTPS_PROXY"
+# Avoid accidental system proxy bypass for this process tree.
+export NO_PROXY=""
+export no_proxy=""
+
+# Isolated home so we do not touch the developer ~/.grok
+export GROK_HOME="$WORKDIR/grok-home"
+mkdir -p "$GROK_HOME"
+
+# Try to re-enable telemetry via env (must still not dial out under privacy).
+export GROK_TELEMETRY_ENABLED=1
+export GROK_TELEMETRY_TRACE_UPLOAD=1
+
+echo "==> gork --version"
+"$BIN" --version || true
+
+echo "==> gork --help (smoke)"
+"$BIN" --help >/dev/null || true
+
+echo "==> gork update (must refuse vendor install without dialing x.ai)"
+set +e
+UPDATE_OUT="$("$BIN" update 2>&1)"
+UPDATE_EC=$?
+set -e
+echo "$UPDATE_OUT" | head -40
+# Expect non-zero or an explicit privacy refusal message.
+if echo "$UPDATE_OUT" | grep -qiE 'never installs from vendor|x\.ai|rebuild from source|Auto-update is not available'; then
+  echo "update path reported privacy/manual messaging (ok)"
+elif [[ "$UPDATE_EC" -ne 0 ]]; then
+  echo "update exited non-zero (ok for privacy build)"
+else
+  echo "WARN: gork update exited 0 without privacy message; host log still checked"
+fi
+
+# Brief pause for any deferred network tasks
+sleep 1
+
+echo "==> Host log:"
+if [[ -s "$LOG" ]]; then
+  sort -u "$LOG" | tee "$WORKDIR/hosts.unique.txt"
+else
+  echo "(empty — no CONNECT/HTTP destinations recorded)"
+  : >"$WORKDIR/hosts.unique.txt"
+fi
+
+if grep -Ei "$DENY_REGEX" "$WORKDIR/hosts.unique.txt" >/dev/null 2>&1; then
+  echo "FAIL: denylisted destination(s) observed:"
+  grep -Ei "$DENY_REGEX" "$WORKDIR/hosts.unique.txt" || true
+  exit 1
+fi
+
+echo "PASS: no denylisted privacy/vendor destinations in egress log"
+echo "WORKDIR=$WORKDIR"

--- a/scripts/privacy_egress_check.sh
+++ b/scripts/privacy_egress_check.sh
@@ -23,6 +23,7 @@ PROXY_PORT="${PRIVACY_EGRESS_PORT:-18080}"
 LISTEN="127.0.0.1:${PROXY_PORT}"
 echo "$WORKDIR" >"$WORKDIR/workdir.path"
 
+# Destinations that must never appear during a privacy-hard-off smoke session.
 DENY_REGEX='(mixpanel\.com|api\.mixpanel\.com|x\.ai|storage\.googleapis\.com|sentry\.io|ingest\.sentry\.io)'
 
 python3 "$ROOT/scripts/privacy_egress_proxy.py" --listen "$LISTEN" --log "$LOG" &
@@ -33,7 +34,7 @@ cleanup() {
 }
 trap cleanup EXIT
 
-# --- Readiness: must confirm proxy accepts connections ---
+# --- Readiness: proxy process alive AND accepts TCP ---
 READY=0
 for _ in $(seq 1 50); do
   if ! kill -0 "$PROXY_PID" 2>/dev/null; then
@@ -52,25 +53,32 @@ if [[ "$READY" -ne 1 ]]; then
 fi
 echo "proxy ready on ${LISTEN} (pid=$PROXY_PID)"
 
-# --- Positive control: prove the proxy records destinations ---
-CONTROL_PORT=$((PROXY_PORT + 1))
-python3 - <<PY &
-import http.server, socketserver
-class H(http.server.BaseHTTPRequestHandler):
-    def do_GET(self):
-        self.send_response(200); self.end_headers(); self.wfile.write(b"ok")
-    def log_message(self, *a): pass
-with socketserver.TCPServer(("127.0.0.1", ${CONTROL_PORT}), H) as httpd:
-    httpd.handle_request()
+# --- Positive control: CONNECT a sentinel host so the log must gain a line ---
+# (CONNECT is logged before the upstream connect attempt; failure is OK.)
+python3 - <<PY
+import socket
+s = socket.create_connection(("127.0.0.1", ${PROXY_PORT}), 2)
+req = (
+    b"CONNECT positive-control.test:443 HTTP/1.1\r\n"
+    b"Host: positive-control.test:443\r\n"
+    b"\r\n"
+)
+s.sendall(req)
+try:
+    s.recv(256)
+except OSError:
+    pass
+s.close()
+print("positive control CONNECT sent")
 PY
-CONTROL_PID=$!
-# wait for control server
-for _ in $(seq 1 30); do
-  if python3 -c "import socket; s=socket.create_connection(('127.0.0.1',${CONTROL_PORT}),0.2); s.close()" 2>/dev/null; then
-    break
-  fi
-  sleep 0.05
-done
+
+if [[ ! -s "$LOG" ]] || ! grep -Fiq 'positive-control.test' "$LOG"; then
+  echo "FAIL: positive control did not record positive-control.test (proxy not capturing)"
+  echo "log contents:"; cat "$LOG" || true
+  exit 1
+fi
+echo "positive control recorded host; clearing log before gork smoke"
+: >"$LOG"
 
 export HTTP_PROXY="http://${LISTEN}"
 export HTTPS_PROXY="http://${LISTEN}"
@@ -79,24 +87,6 @@ export http_proxy="$HTTP_PROXY"
 export https_proxy="$HTTPS_PROXY"
 export NO_PROXY=""
 export no_proxy=""
-
-# Fetch via proxy so host log must gain 127.0.0.1 (or localhost)
-python3 - <<PY
-import urllib.request
-proxy = urllib.request.ProxyHandler({"http": "http://${LISTEN}", "https": "http://${LISTEN}"})
-opener = urllib.request.build_opener(proxy)
-opener.open("http://127.0.0.1:${CONTROL_PORT}/", timeout=5).read()
-print("positive control request ok")
-PY
-wait "$CONTROL_PID" 2>/dev/null || true
-
-if [[ ! -s "$LOG" ]] || ! grep -Eiq '127\.0\.0\.1|localhost' "$LOG"; then
-  echo "FAIL: positive control did not record a host in proxy log (proxy not capturing)"
-  echo "log contents:"; cat "$LOG" || true
-  exit 1
-fi
-echo "positive control recorded host(s); clearing log before gork smoke"
-: >"$LOG"
 
 export GROK_HOME="$WORKDIR/grok-home"
 mkdir -p "$GROK_HOME"
@@ -135,7 +125,7 @@ echo "==> Host log after gork:"
 if [[ -s "$LOG" ]]; then
   sort -u "$LOG" | tee "$WORKDIR/hosts.unique.txt"
 else
-  echo "(empty — no CONNECT/HTTP destinations recorded after positive control clear)"
+  echo "(empty — no CONNECT/HTTP destinations after positive control clear)"
   : >"$WORKDIR/hosts.unique.txt"
 fi
 

--- a/scripts/privacy_egress_check.sh
+++ b/scripts/privacy_egress_check.sh
@@ -15,19 +15,14 @@ if [[ ! -x "$BIN" ]]; then
   BIN=target/release/gork
 fi
 
-# Prefer runner temp on GHA; fall back to local TMPDIR.
 BASE_TMP="${RUNNER_TEMP:-${TMPDIR:-/tmp}}"
 WORKDIR="${PRIVACY_EGRESS_WORKDIR:-$(mktemp -d "${BASE_TMP}/gork-privacy-egress.XXXXXX")}"
 mkdir -p "$WORKDIR"
 LOG="$WORKDIR/hosts.txt"
 PROXY_PORT="${PRIVACY_EGRESS_PORT:-18080}"
 LISTEN="127.0.0.1:${PROXY_PORT}"
-# Export for CI artifact upload path discovery.
-echo "PRIVACY_EGRESS_WORKDIR=$WORKDIR" >>"${GITHUB_ENV:-/dev/null}" 2>/dev/null || true
 echo "$WORKDIR" >"$WORKDIR/workdir.path"
 
-# Destinations that must never appear during a privacy-hard-off smoke session.
-# (Model/auth hosts are not exercised here — no login; update/telemetry must stay quiet.)
 DENY_REGEX='(mixpanel\.com|api\.mixpanel\.com|x\.ai|storage\.googleapis\.com|sentry\.io|ingest\.sentry\.io)'
 
 python3 "$ROOT/scripts/privacy_egress_proxy.py" --listen "$LISTEN" --log "$LOG" &
@@ -38,16 +33,43 @@ cleanup() {
 }
 trap cleanup EXIT
 
-# Wait for proxy
+# --- Readiness: must confirm proxy accepts connections ---
+READY=0
 for _ in $(seq 1 50); do
-  if (echo >"/dev/tcp/127.0.0.1/${PROXY_PORT}") >/dev/null 2>&1; then
-    break
+  if ! kill -0 "$PROXY_PID" 2>/dev/null; then
+    echo "FAIL: privacy egress proxy process exited during startup (pid=$PROXY_PID)"
+    exit 1
   fi
-  # bash /dev/tcp may be missing; fall back to python
-  if python3 -c "import socket; s=socket.create_connection(('127.0.0.1',${PROXY_PORT}),1); s.close()" 2>/dev/null; then
+  if python3 -c "import socket; s=socket.create_connection(('127.0.0.1',${PROXY_PORT}),0.2); s.close()" 2>/dev/null; then
+    READY=1
     break
   fi
   sleep 0.1
+done
+if [[ "$READY" -ne 1 ]]; then
+  echo "FAIL: privacy egress proxy did not become ready on ${LISTEN}"
+  exit 1
+fi
+echo "proxy ready on ${LISTEN} (pid=$PROXY_PID)"
+
+# --- Positive control: prove the proxy records destinations ---
+CONTROL_PORT=$((PROXY_PORT + 1))
+python3 - <<PY &
+import http.server, socketserver
+class H(http.server.BaseHTTPRequestHandler):
+    def do_GET(self):
+        self.send_response(200); self.end_headers(); self.wfile.write(b"ok")
+    def log_message(self, *a): pass
+with socketserver.TCPServer(("127.0.0.1", ${CONTROL_PORT}), H) as httpd:
+    httpd.handle_request()
+PY
+CONTROL_PID=$!
+# wait for control server
+for _ in $(seq 1 30); do
+  if python3 -c "import socket; s=socket.create_connection(('127.0.0.1',${CONTROL_PORT}),0.2); s.close()" 2>/dev/null; then
+    break
+  fi
+  sleep 0.05
 done
 
 export HTTP_PROXY="http://${LISTEN}"
@@ -55,23 +77,37 @@ export HTTPS_PROXY="http://${LISTEN}"
 export ALL_PROXY="http://${LISTEN}"
 export http_proxy="$HTTP_PROXY"
 export https_proxy="$HTTPS_PROXY"
-# Avoid accidental system proxy bypass for this process tree.
 export NO_PROXY=""
 export no_proxy=""
 
-# Isolated home so we do not touch the developer ~/.grok
+# Fetch via proxy so host log must gain 127.0.0.1 (or localhost)
+python3 - <<PY
+import urllib.request
+proxy = urllib.request.ProxyHandler({"http": "http://${LISTEN}", "https": "http://${LISTEN}"})
+opener = urllib.request.build_opener(proxy)
+opener.open("http://127.0.0.1:${CONTROL_PORT}/", timeout=5).read()
+print("positive control request ok")
+PY
+wait "$CONTROL_PID" 2>/dev/null || true
+
+if [[ ! -s "$LOG" ]] || ! grep -Eiq '127\.0\.0\.1|localhost' "$LOG"; then
+  echo "FAIL: positive control did not record a host in proxy log (proxy not capturing)"
+  echo "log contents:"; cat "$LOG" || true
+  exit 1
+fi
+echo "positive control recorded host(s); clearing log before gork smoke"
+: >"$LOG"
+
 export GROK_HOME="$WORKDIR/grok-home"
 mkdir -p "$GROK_HOME"
-
-# Try to re-enable telemetry via env (must still not dial out under privacy).
 export GROK_TELEMETRY_ENABLED=1
 export GROK_TELEMETRY_TRACE_UPLOAD=1
 
 echo "==> gork --version"
-"$BIN" --version || true
+"$BIN" --version
 
 echo "==> gork --help (smoke)"
-"$BIN" --help >/dev/null || true
+"$BIN" --help >/dev/null
 
 echo "==> gork update (must refuse vendor install without dialing x.ai)"
 set +e
@@ -79,23 +115,27 @@ UPDATE_OUT="$("$BIN" update 2>&1)"
 UPDATE_EC=$?
 set -e
 echo "$UPDATE_OUT" | head -40
-# Expect non-zero or an explicit privacy refusal message.
-if echo "$UPDATE_OUT" | grep -qiE 'never installs from vendor|x\.ai|rebuild from source|Auto-update is not available'; then
+if echo "$UPDATE_OUT" | grep -qiE 'never installs from vendor|rebuild from source|Auto-update is not available'; then
   echo "update path reported privacy/manual messaging (ok)"
 elif [[ "$UPDATE_EC" -ne 0 ]]; then
   echo "update exited non-zero (ok for privacy build)"
 else
-  echo "WARN: gork update exited 0 without privacy message; host log still checked"
+  echo "FAIL: gork update exited 0 without privacy refusal message"
+  exit 1
 fi
 
-# Brief pause for any deferred network tasks
+if ! kill -0 "$PROXY_PID" 2>/dev/null; then
+  echo "FAIL: proxy died during gork smoke"
+  exit 1
+fi
+
 sleep 1
 
-echo "==> Host log:"
+echo "==> Host log after gork:"
 if [[ -s "$LOG" ]]; then
   sort -u "$LOG" | tee "$WORKDIR/hosts.unique.txt"
 else
-  echo "(empty — no CONNECT/HTTP destinations recorded)"
+  echo "(empty — no CONNECT/HTTP destinations recorded after positive control clear)"
   : >"$WORKDIR/hosts.unique.txt"
 fi
 

--- a/scripts/privacy_egress_proxy.py
+++ b/scripts/privacy_egress_proxy.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""Minimal HTTP CONNECT proxy that records destination hosts.
+
+Used by Gork Build privacy CI: run the release binary through this proxy and
+assert no denylisted destinations appear. HTTPS traffic is not decrypted —
+only CONNECT hostnames are logged (sufficient for egress inventory checks).
+
+Usage:
+  python3 scripts/privacy_egress_proxy.py --listen 127.0.0.1:18080 --log /tmp/hosts.txt
+"""
+
+from __future__ import annotations
+
+import argparse
+import select
+import socket
+import socketserver
+import sys
+import threading
+from typing import Optional
+
+
+class HostLog:
+    def __init__(self, path: str) -> None:
+        self._path = path
+        self._lock = threading.Lock()
+        open(path, "w", encoding="utf-8").close()
+
+    def add(self, host: str) -> None:
+        host = host.strip().lower()
+        if not host:
+            return
+        with self._lock:
+            with open(self._path, "a", encoding="utf-8") as f:
+                f.write(host + "\n")
+
+
+class ProxyHandler(socketserver.BaseRequestHandler):
+    log: HostLog  # set on server class
+
+    def handle(self) -> None:
+        self.request.settimeout(30.0)
+        try:
+            data = self._recv_headers()
+        except OSError:
+            return
+        if not data:
+            return
+        first = data.split(b"\r\n", 1)[0].decode("latin-1", errors="replace")
+        parts = first.split()
+        if len(parts) < 2:
+            return
+        method, target = parts[0].upper(), parts[1]
+        if method == "CONNECT":
+            hostport = target
+            host = hostport.split(":")[0]
+            self.log.add(host)
+            try:
+                remote = self._connect(hostport)
+            except OSError:
+                self.request.sendall(b"HTTP/1.1 502 Bad Gateway\r\n\r\n")
+                return
+            self.request.sendall(b"HTTP/1.1 200 Connection Established\r\n\r\n")
+            self._pipe(self.request, remote)
+            return
+
+        # Plain HTTP: parse Host header for logging
+        host = self._host_from_headers(data) or "unknown"
+        self.log.add(host.split(":")[0])
+        # Best-effort forward for HTTP (rarely used by the CLI).
+        try:
+            remote = self._connect(host if ":" in host else f"{host}:80")
+            remote.sendall(data)
+            self._pipe(self.request, remote)
+        except OSError:
+            pass
+
+    def _recv_headers(self) -> bytes:
+        buf = b""
+        while b"\r\n\r\n" not in buf and len(buf) < 65536:
+            chunk = self.request.recv(4096)
+            if not chunk:
+                break
+            buf += chunk
+        return buf
+
+    @staticmethod
+    def _host_from_headers(data: bytes) -> Optional[str]:
+        for line in data.split(b"\r\n"):
+            if line.lower().startswith(b"host:"):
+                return line.split(b":", 1)[1].strip().decode("latin-1", errors="replace")
+        return None
+
+    @staticmethod
+    def _connect(hostport: str) -> socket.socket:
+        if ":" in hostport:
+            host, port_s = hostport.rsplit(":", 1)
+            port = int(port_s)
+        else:
+            host, port = hostport, 443
+        remote = socket.create_connection((host, port), timeout=15)
+        remote.settimeout(30.0)
+        return remote
+
+    @staticmethod
+    def _pipe(a: socket.socket, b: socket.socket) -> None:
+        sockets = [a, b]
+        try:
+            while True:
+                r, _, _ = select.select(sockets, [], [], 30.0)
+                if not r:
+                    break
+                for s in r:
+                    other = b if s is a else a
+                    try:
+                        data = s.recv(8192)
+                    except OSError:
+                        return
+                    if not data:
+                        return
+                    try:
+                        other.sendall(data)
+                    except OSError:
+                        return
+        finally:
+            for s in (a, b):
+                try:
+                    s.close()
+                except OSError:
+                    pass
+
+
+class ThreadingTCPServer(socketserver.ThreadingTCPServer):
+    allow_reuse_address = True
+    daemon_threads = True
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--listen", default="127.0.0.1:18080")
+    ap.add_argument("--log", required=True, help="Append-only host log path")
+    args = ap.parse_args()
+    host, port_s = args.listen.rsplit(":", 1)
+    port = int(port_s)
+    ProxyHandler.log = HostLog(args.log)
+    with ThreadingTCPServer((host, port), ProxyHandler) as srv:
+        print(f"privacy_egress_proxy listening on {host}:{port}, log={args.log}", flush=True)
+        try:
+            srv.serve_forever()
+        except KeyboardInterrupt:
+            pass
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Independent follow-up for end-to-end-ish **network egress capture** (assessment residual):

- `scripts/privacy_egress_proxy.py` — CONNECT proxy that logs destination hosts without TLS interception
- `scripts/privacy_egress_check.sh` — runs release `gork` (`--version`, `--help`, `update`) with telemetry env forced on via `HTTP(S)_PROXY`
- CI job **Privacy egress capture** after **Build gork**; fails if denylist hosts appear (`mixpanel`, `x.ai`, `storage.googleapis.com`, `sentry.io`)

This does **not** replace a full authenticated agent session capture; it proves the product binary does not dial vendor update/analytics hosts on the smoke paths that previously had bypass risk.

## Stack
Base: `fix/vendor-update-hard-off` (PR #9). Merge after #9 or retarget `main`.

## Test plan
- [x] Proxy script `py_compile`s
- [ ] CI Privacy egress capture job green (needs build artifact)
- [x] Denylist documented in script
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/thedavidweng/gork-build/pull/11" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->