### PR TITLE
fix(release): disable PDB generation on Windows builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -159,6 +159,11 @@ jobs:
 
       - name: Build gork (release)
         shell: bash
+        env:
+          # MSVC: this binary's symbol count exceeds PDB limits
+          # (LNK4319/LNK1318 on both win32 targets). Release artifacts ship
+          # without debug info anyway — disable PDB generation outright.
+          RUSTFLAGS: ${{ runner.os == 'Windows' && '-C link-arg=/DEBUG:NONE' || '' }}
         run: |
           set -euo pipefail
           if [[ -n "${{ matrix.target }}" ]]; then

--- a/maint/control/.github/workflows/release.yml
+++ b/maint/control/.github/workflows/release.yml
@@ -159,6 +159,11 @@ jobs:
 
       - name: Build gork (release)
         shell: bash
+        env:
+          # MSVC: this binary's symbol count exceeds PDB limits
+          # (LNK4319/LNK1318 on both win32 targets). Release artifacts ship
+          # without debug info anyway — disable PDB generation outright.
+          RUSTFLAGS: ${{ runner.os == 'Windows' && '-C link-arg=/DEBUG:NONE' || '' }}
         run: |
           set -euo pipefail
           if [[ -n "${{ matrix.target }}" ]]; then


### PR DESCRIPTION
Both win32 release targets failed at **link** time (past the protoc fix from #30) with PDB limit errors: `LNK4319: A PDB limit was hit while adding public symbols` (x64) / `LNK1318: Unexpected PDB error; LIMIT (12)` (arm64). The gork binary's symbol count exceeds PDB format limits.

Release artifacts ship without debug info anyway — pass `/DEBUG:NONE` via `RUSTFLAGS` on the Windows matrix entries only. Live workflow + control template updated together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)